### PR TITLE
Decoupled and genericized tooltips

### DIFF
--- a/_includes/git-wiki/components/action_btn/page_actions.html
+++ b/_includes/git-wiki/components/action_btn/page_actions.html
@@ -2,57 +2,29 @@
 
     {% if site.disable_edit != true %}
     <li class="tools-button new">
-        <a class="primary-button iconed icon-toolbar icon-add" target="_blank" href="{{ site.github.repository_url }}/new/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}{{ site.wiki_folder }}?filename="></a>
-        <div class="tooltip">Add New Page</div>
+        <a class="primary-button iconed icon-toolbar icon-add" target="_blank" href="{{ site.github.repository_url }}/new/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}{{ site.wiki_folder }}?filename=" data-tooltip-text="Add New Page"></a>
     </li>
     <li class="tools-button edit">
-        <a class="primary-button iconed icon-toolbar icon-edit" target="_blank" href="{{ site.github.repository_url }}/edit/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}"></a>
-        <div class="tooltip">Edit Page</div>
+        <a class="primary-button iconed icon-toolbar icon-edit" target="_blank" href="{{ site.github.repository_url }}/edit/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}" data-tooltip-text="Edit Page"></a>
     </li>
     {% endif %}
     <li class="tools-button history">
-        <a class="primary-button iconed icon-toolbar icon-history" target="_blank" href="{{ site.github.repository_url }}/commits/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}"></a>
-        <div class="tooltip">Page History</div>
+        <a class="primary-button iconed icon-toolbar icon-history" target="_blank" href="{{ site.github.repository_url }}/commits/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}" data-tooltip-text="Page History"></a>
     </li>
     <li class="tools-button source">
-        <a class="primary-button iconed icon-toolbar icon-source" target="_blank" href="{{ site.github.repository_url }}/blob/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}"></a>
-        <div class="tooltip">Page Source</div>
+        <a class="primary-button iconed icon-toolbar icon-source" target="_blank" href="{{ site.github.repository_url }}/blob/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}" data-tooltip-text="Page Source"></a>
     </li>
     <li class="tools-button page-width-toggle">
-        <a class="primary-button iconed icon-toolbar icon-expand"></a>
-        <div class="tooltip">Expand Page Width</div>
+        <a class="primary-button iconed icon-toolbar icon-expand" data-tooltip-text="Expand Page Width"></a>
     </li>
     <li class="tools-button more-options">
-        <a class="primary-button iconed icon-toolbar icon-overflow"></a>
-        <div class="tooltip menu">
-            <div>More Options</div>
-            <div class="menu-content">
-                <div class="menu-radio">
-                    <div class="menu-button theme-light-switcher"><a class="iconed icon-toolbar icon-themes-light"></a></div>
-                    <div class="menu-button theme-dark-switcher"><a class="iconed icon-toolbar icon-themes-dark"></a></div>
-                </div>
-                <div class="menu-radio">
-                    <div class="menu-button header-graphic-switcher-default"><a class="graphic-button"></a></div>
-                    <div class="menu-button header-graphic-switcher-second"><a class="graphic-button"></a></div>
-                </div>
-                {% if site.disable_edit != true %}
-                <hr/>
-                <div class="menu-button delete">
-                    <a target="_blank" href="{{ site.github.repository_url }}/delete/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}">
-                        <span class="iconed icon-toolbar icon-delete label dim">Delete Page</span>
-                    </a>
-                </div>
-                {% endif %}
-            </div>
-        </div>
+        <a class="primary-button iconed icon-toolbar icon-overflow" data-tooltip-text="More Options" data-tooltip-menu="more-options" data-delete-page-url="{{ site.github.repository_url }}/delete/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}"></a>
     </li>
     <li class="tools-button prose new">
-        <a class="primary-button iconed icon-toolbar icon-add" target="_blank" href="http://prose.io/#{{site.github.repository_nwo}}/new/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}{{ site.wiki_folder }}"></a>
-        <div class="tooltip">Prose.io - Add New Page</div>
+        <a class="primary-button iconed icon-toolbar icon-add" target="_blank" href="http://prose.io/#{{site.github.repository_nwo}}/new/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}{{ site.wiki_folder }}" data-tooltip-text="Prose.io - Add New Page"></a>
     </li>
     <li class="tools-button prose edit">
-        <a class="primary-button iconed icon-toolbar icon-edit" target="_blank" href="http://prose.io/#{{site.github.repository_nwo}}/edit/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}{{page.path | escape}}"></a>
-        <div class="tooltip">Prose.io - Edit Page</div>
+        <a class="primary-button iconed icon-toolbar icon-edit" target="_blank" href="http://prose.io/#{{site.github.repository_nwo}}/edit/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}{{page.path | escape}}" data-tooltip-text="Prose.io - Edit Page"></a>
     </li>
 
 </ul>

--- a/_includes/head-after-styles.html
+++ b/_includes/head-after-styles.html
@@ -5,3 +5,4 @@
 <script type="module" src="/assets/js/virtualpages.js"></script>
 <script type="module" src="/assets/js/sidebar.js"></script>
 <script type="module" src="/assets/js/linkscheck.js"></script>
+<script type="module" src="/assets/js/tooltips.js"></script>

--- a/assets/css/overrides.css
+++ b/assets/css/overrides.css
@@ -3,7 +3,7 @@
 :root {
     --width-sidebar: 280px;
     --height-mobile-header: 50px;
-    --height-menu-button: 39px;  /* static value based on current text size/padding settings */
+    --height-tooltip-min: 39px;  /* static value based on current text size/padding settings */
     --spacing-primary: 30px;
     --spacing-intermediate: 20px;
     --spacing-secondary: 15px;
@@ -241,7 +241,7 @@ pre code {
 table table *,
 pre code,
 table pre,
-.tools-button .tooltip {
+.tooltip {
     font-size: calc(var(--font-size-base) * 0.8);
 }
 
@@ -374,6 +374,215 @@ li::marker,
     display: none;
 }
 
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ TOOLTIPS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+.tooltip {
+    --offset-y: 40px;
+    --max-width-open: 210px;
+    width: max-content;
+    min-height: var(--height-tooltip-min);
+    background: var(--bg-tooltip);
+    color: var(--color-secondary);
+    font-weight: var(--font-weight-base);
+    line-height: calc(var(--font-line-height) * 1.25); /* to normalize regardless of inherited differences */
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    cursor: default;
+    padding: var(--spacing-minor) var(--spacing-secondary);
+    border-radius: var(--radius-primary);
+    filter: var(--filter-shadow-secondary); /* to conform to entire shape of element, including pseudo-element */
+    position: fixed;
+    top: calc(var(--offset-y) + var(--top));
+    left: var(--left);
+    z-index: 2;
+    pointer-events: none; /* otherwise (for ::before at least) will block :active styling */
+    transform: translateX(-50%); /* center element to fixed coord */
+    transition: opacity 150ms ease-out, margin 150ms ease-in;
+}
+
+.tooltip.offset-add {
+    --offset-y: 50px; /* for `.primary-button` butttons, mainly to align toolbar buttons more pleasantly with search box edge */
+}
+
+.tooltip.hidden {
+    opacity: 0;
+    margin-top: 10px;
+}
+
+.tooltip.visible {
+    opacity: 1;
+    margin-top: 5px;
+}
+
+/* Tooltip/overflow menu pop-up */
+.tooltip.menu {
+    max-width: 150px; /* workaround as unit-less values can't be used with transitions */
+    max-height: var(--height-tooltip-min);
+    user-select: none; /* prevent text selection */
+    transition: max-width 150ms ease-in-out, max-height 200ms ease-out, opacity 150ms ease-out, margin 150ms ease-in, transform 200ms;
+}
+
+.tooltip.menu::before {
+    --height: 8px;
+    width: 20px;
+    height: var(--height);
+    background: var(--bg-tooltip);
+    content: '';
+    display: block;
+    clip-path: polygon(50% 0%, 0% 100%, 100% 100%); /* triangle */
+    position: absolute;
+    top: 0;
+    transition: top 200ms ease-out, transform 200ms;
+}
+
+.tooltip.menu.tooltip-menu-open::before {
+    top: calc(-1 * var(--height));
+    transform: translateX(var(--menu-open-offset));
+}
+
+.tooltip.menu > div {
+    flex-basis: 100%; /* force wrapping top-level children */
+}
+
+.tooltip.menu.tooltip-menu-open {
+    max-width: var(--max-width-open);
+    max-height: 300px;
+    pointer-events: all;
+    padding-bottom: var(--spacing-secondary);
+    transform: translateX(calc(-50% - var(--menu-open-offset)));
+}
+
+.tooltip.menu .menu-content {
+    width: 0;
+    height: 0;
+    opacity: 0;
+    margin-top: var(--spacing-minor);
+    position: relative;
+    top: 5px;
+    transition: width 150ms ease-in-out, height 200ms ease-out, opacity 150ms ease-in, top 150ms ease-in; /* timing functions of dimensions to match parent */
+}
+
+.tooltip.menu.tooltip-menu-open .menu-content {
+    width: 100%;
+    height: 100%;
+    opacity: 1;
+    top: 0;
+}
+
+.tooltip.menu hr {
+    background: var(--bg-primary);
+    margin: var(--spacing-secondary) 0;
+}
+
+.tooltip.menu .menu-button {
+    width: 100%;
+    border-radius: var(--radius-full);
+    border: var(--border-width) solid var(--color-buttons-inset);
+}
+
+.tooltip.menu .menu-button.standalone:not(:last-child) {
+    margin-bottom: calc(var(--spacing-minor) * 2);
+}
+
+.tooltip.menu .menu-button:hover {
+    border-color: var(--color-buttons-hover);
+}
+
+.tooltip.menu .menu-button:active,
+.tooltip.menu .menu-button.active {
+    border-color: var(--color-accent);
+}
+
+.tooltip.menu .menu-button a {
+    width: 100%;
+    height: calc(var(--height-tooltip-min) - (var(--border-width) * 2));
+    color: inherit;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2px;
+    cursor: pointer;
+}
+
+.tooltip.menu .menu-button .iconed.label {
+    display: inline-flex;
+    align-items: center;
+}
+
+/* Radio buttons */
+.tooltip.menu .menu-radio {
+    display: flex;
+    gap: var(--spacing-minor);
+}
+
+.tooltip.menu .menu-radio ~ .menu-radio {
+    margin-top: calc(var(--spacing-minor) * 2);
+}
+
+.tooltip.menu .menu-radio .active {
+    position: relative;
+}
+
+/* Active setting badge indicator */
+.tooltip.menu .menu-radio .menu-button::before,
+.tooltip.menu .menu-radio .menu-button::after {
+    width: 18px;
+    height: 18px;
+    background: var(--color-accent);
+    content: '';
+    display: block;
+    opacity: 0;
+    border-radius: var(--radius-circle);
+    position: absolute;
+    top: calc(-1 * var(--border-width) - 3px);
+    right: calc(-1 * var(--border-width));
+    transform: scale(0);
+    transform-origin: 50% 50%;
+    transition: transform 200ms var(--timing-bezier-1);
+    z-index: 1;
+}
+
+.tooltip.menu .menu-radio .menu-button::before {
+    box-shadow: var(--shadow-secondary);
+}
+
+.tooltip.menu .menu-radio .menu-button::after {
+    background: var(--color-accent-foreground);
+    transition: opacity 200ms var(--timing-bezier-1);
+}
+
+.tooltip.menu .menu-radio .menu-button.active::before,
+.tooltip.menu .menu-radio .menu-button.active::after {
+    transform: scale(1);
+    opacity: 1;
+}
+
+/* Buttons - Graphic/image-based */
+.tooltip.menu .graphic-button::before {
+    width: 100%;
+    height: 100%;
+    background-color: var(--color-accent);
+    background-repeat: no-repeat;
+    content: '';
+    display: block;
+    border-radius: var(--radius-full);
+}
+
+.tooltip.menu .header-graphic-switcher-default .graphic-button::before {
+    background-image: var(--header-graphic-default);
+    background-size: 80px; /* using absolute rather than relative units to avoid scaling when menu toggled */
+    background-position: 1px -26px;
+}
+
+.tooltip.menu .header-graphic-switcher-second .graphic-button::before {
+    background-image: var(--header-graphic-second);
+    background-size: 115px;
+    background-position: -30px -17px;
+}
+
 
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ EDITING TOOLBAR ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
@@ -438,178 +647,8 @@ li::marker,
     filter: var(--filter-button-active);
 }
 
-.tools-button .primary-button.iconed::before,
-.tools-button .tooltip {
+.tools-button .primary-button.iconed::before {
     pointer-events: none; /* otherwise (for ::before at least) will block :active styling */
-}
-
-.tools-button .tooltip,
-.git-wiki-tools.menu-visible .tools-button:not(.menu-open) .tooltip /* hide all other tooltips beside the one with a menu active, to avoid tooltip overlaps */
-{
-    opacity: 0;
-    top: 60px;
-}
-
-.tools-button .tooltip {
-    width: max-content;
-    background: var(--bg-tooltip);
-    color: var(--color-secondary);
-    text-align: center;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-wrap: wrap;
-    cursor: default;
-    padding: var(--spacing-minor) var(--spacing-secondary);
-    border-radius: var(--radius-primary);
-    filter: var(--filter-shadow-secondary); /* to conform to entire shape of element, including pseudo-element */
-    position: absolute;
-    z-index: 2;
-    transition: opacity 150ms ease-out, top 150ms ease-in;
-}
-
-.tools-button .primary-button:hover ~ .tooltip,
-.tools-button .primary-button:active ~ .tooltip,
-.tools-button.menu-open .tooltip.menu {
-    opacity: 1;
-    top: 55px;
-}
-
-/* Tooltip/overflow menu pop-up */
-.tools-button .tooltip.menu {
-    max-width: 150px; /* workaround as unit-less values can't be used with transitions */
-    max-height: var(--height-menu-button);
-    user-select: none; /* prevent text selection */
-    transition: max-width 150ms ease-in-out, max-height 200ms ease-out, opacity 150ms ease-out, top 150ms ease-in;
-}
-
-.tools-button .tooltip.menu::before {
-    --height: 8px;
-    width: 20px;
-    height: var(--height);
-    background: var(--bg-tooltip);
-    content: '';
-    display: block;
-    clip-path: polygon(50% 0%, 0% 100%, 100% 100%); /* triangle */
-    position: absolute;
-    top: 0;
-    transition: top 200ms ease-out;
-}
-
-.tools-button.menu-open .tooltip.menu::before {
-    top: calc(-1 * var(--height));
-}
-
-.tools-button .tooltip.menu > div {
-    flex-basis: 100%; /* force wrapping top-level children */
-}
-
-.tools-button.menu-open .tooltip.menu {
-    max-width: 210px;
-    max-height: 300px;
-    pointer-events: all;
-    padding-bottom: var(--spacing-secondary);
-}
-
-.tools-button .tooltip.menu .menu-content {
-    width: 0;
-    height: 0;
-    opacity: 0;
-    margin-top: var(--spacing-minor);
-    position: relative;
-    top: 5px;
-    transition: width 150ms ease-in-out, height 200ms ease-out, opacity 150ms ease-in, top 150ms ease-in; /* timing functions of dimensions to match parent */
-}
-
-.tools-button.menu-open .tooltip.menu .menu-content {
-    width: 100%;
-    height: 100%;
-    opacity: 1;
-    top: 0;
-}
-
-.tools-button .tooltip.menu hr {
-    background: var(--bg-primary);
-    margin: var(--spacing-secondary) 0;
-}
-
-.tools-button .tooltip.menu .menu-button {
-    width: 100%;
-    border-radius: var(--radius-full);
-    border: var(--border-width) solid var(--color-buttons-inset);
-}
-
-.tools-button .tooltip.menu .menu-button:hover {
-    border-color: var(--color-buttons-hover);
-}
-
-.tools-button .tooltip.menu .menu-button:active,
-.tools-button .tooltip.menu .menu-button.active {
-    border-color: var(--color-accent);
-}
-
-.tools-button .tooltip.menu .menu-button a {
-    width: 100%;
-    height: calc(var(--height-menu-button) - (var(--border-width) * 2));
-    color: inherit;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 2px;
-    cursor: pointer;
-}
-
-.tools-button .tooltip.menu .menu-button .iconed.label {
-    display: inline-flex;
-    align-items: center;
-}
-
-/* Radio buttons */
-.tools-button .tooltip.menu .menu-radio {
-    display: flex;
-    gap: var(--spacing-minor);
-}
-
-.tools-button .tooltip.menu .menu-radio ~ .menu-radio {
-    margin-top: calc(var(--spacing-minor) * 2);
-}
-
-.tools-button .tooltip.menu .menu-radio .active {
-    position: relative;
-}
-
-/* Active setting badge indicator */
-.tools-button .tooltip.menu .menu-radio .menu-button::before,
-.tools-button .tooltip.menu .menu-radio .menu-button::after {
-    width: 18px;
-    height: 18px;
-    background: var(--color-accent);
-    content: '';
-    display: block;
-    opacity: 0;
-    border-radius: var(--radius-circle);
-    position: absolute;
-    top: calc(-1 * var(--border-width) - 3px);
-    right: calc(-1 * var(--border-width));
-    transform: scale(0);
-    transform-origin: 50% 50%;
-    transition: transform 200ms var(--timing-bezier-1);
-    z-index: 1;
-}
-
-.tools-button .tooltip.menu .menu-radio .menu-button::before {
-    box-shadow: var(--shadow-secondary);
-}
-
-.tools-button .tooltip.menu .menu-radio .menu-button::after {
-    background: var(--color-accent-foreground);
-    transition: opacity 200ms var(--timing-bezier-1);
-}
-
-.tools-button .tooltip.menu .menu-radio .menu-button.active::before,
-.tools-button .tooltip.menu .menu-radio .menu-button.active::after {
-    transform: scale(1);
-    opacity: 1;
 }
 
 /* Buttons - icons. Named such so they can also be reused in documentation */
@@ -622,15 +661,15 @@ li::marker,
 }
 
 /* For buttons with icon + text label */
-.tools-button .tooltip.menu .iconed.label::before {
+.tooltip.menu .iconed.label::before {
     margin-right: var(--spacing-minor);
 }
 
-.tools-button .tooltip.menu .iconed.label.dim::before {
+.tooltip.menu .iconed.label.dim::before {
     opacity: 0.5; /* dim icon to attract less attention. Made for delete button */
 }
 
-.tools-button .tooltip.menu .menu-radio .menu-button.active::after {
+.tooltip.menu .menu-radio .menu-button.active::after {
     -webkit-mask-image: url("/assets/images/ui.svg#icons-badge-tick");
     mask-image: url("/assets/images/ui.svg#icons-badge-tick");
 }
@@ -700,29 +739,6 @@ body.expanded-width-true .icon-toolbar.icon-expand::before {
 
 .tools-button.prose .primary-button.iconed::before {
     background: var(--color-accent-foreground);
-}
-
-/* Buttons - Graphic/image-based */
-.tools-button .graphic-button::before {
-    width: 100%;
-    height: 100%;
-    background-color: var(--color-accent);
-    background-repeat: no-repeat;
-    content: '';
-    display: block;
-    border-radius: var(--radius-full);
-}
-
-.tools-button .header-graphic-switcher-default .graphic-button::before {
-    background-image: var(--header-graphic-default);
-    background-size: 80px; /* using absolute rather than relative units to avoid scaling when menu toggled */
-    background-position: 1px -26px;
-}
-
-.tools-button .header-graphic-switcher-second .graphic-button::before {
-    background-image: var(--header-graphic-second);
-    background-size: 115px;
-    background-position: -30px -17px;
 }
 
 
@@ -2132,9 +2148,9 @@ h2.heading-with-frag-id .heading-frag-id-link {
     padding: 0;
 }
 
-/* `.menu-closed`/`.menu-open` classes via custom JS (overriding default JS) */
+/* `.mobile-menu-closed`/`.mobile-menu-open` classes via custom JS (overriding default JS) */
 #git-wiki-mobile-header > button::before,
-.menu-closed #git-wiki-mobile-header > button::before {
+.mobile-menu-closed #git-wiki-mobile-header > button::before {
     width: 24px;
     height: 24px;
     content: '';
@@ -2144,7 +2160,7 @@ h2.heading-with-frag-id .heading-frag-id-link {
     mask-image: url("/assets/images/ui.svg#icons-hamburger-menu");
 }
 
-.menu-open #git-wiki-mobile-header > button::before {
+.mobile-menu-open #git-wiki-mobile-header > button::before {
     -webkit-mask-image: url("/assets/images/ui.svg#icons-hamburger-menu-close");
     mask-image: url("/assets/images/ui.svg#icons-hamburger-menu-close");
 }
@@ -2409,14 +2425,14 @@ footer {
     }
 
     #git-wiki-sidebar,
-    .menu-closed #git-wiki-sidebar {
+    .mobile-menu-closed #git-wiki-sidebar {
         max-height: 100px;
         opacity: 0;
         top: calc(var(--height-mobile-header) + var(--spacing-minor) * 2);
         pointer-events: none;
     }
 
-    .menu-open #git-wiki-sidebar {
+    .mobile-menu-open #git-wiki-sidebar {
         max-height: 100vh;
         opacity: 1;
         top: calc(var(--height-mobile-header) + var(--spacing-minor));
@@ -2438,7 +2454,7 @@ footer {
         transition: top 200ms ease-out;
     }
 
-    .menu-open #git-wiki-sidebar::before {
+    .mobile-menu-open #git-wiki-sidebar::before {
         top: calc(-1 * var(--height));
     }
 
@@ -2458,11 +2474,11 @@ footer {
         transition: opacity 500ms;
     }
 
-    body > .wrapper.menu-open::before {
+    body > .wrapper.mobile-menu-open::before {
         opacity: 0.8;
     }
 
-    .menu-open .git-wiki-page > section {
+    .mobile-menu-open .git-wiki-page > section {
         pointer-events: none; /* prevent interactable elements being clicked behind menu */
     }
 
@@ -2615,8 +2631,8 @@ footer {
         top: 0; /* to align icon w/ new font size */
     }
 
-    .tools-button .tooltip:not(.tooltip.menu) {
-        display: none; /* hide tooltips at narrowest viewports to avoid page width issue from the text */
+    .tooltip:not(.tooltip.menu) {
+        display: none; /* hide tooltips at narrowest viewports */
     }
 
     .infobox {

--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -1,5 +1,9 @@
 // General reusable functions for Javascript modules (avoids race conditions for deferred scripts)
 
+export function getRect(el) {
+    return el.getBoundingClientRect()
+}
+
 export function getKeyByValue(object, value) {
     return Object.keys(object).find(key => object[key] === value)
 }
@@ -16,6 +20,14 @@ export function filterArrayByObjVal(array, key, value) {
 
 export function getIndexByValue(array, key, value) {
     return array.findIndex(obj => obj[key] == value);
+}
+
+export function clamp(num, min, max) {
+    return num <= min
+        ? min
+        : num >= max
+            ? max
+            : num
 }
 
 export function removeChildText(parent) {
@@ -83,4 +95,31 @@ export async function checkVp(funcName) {
     } else {
         funcName();
     }
+}
+
+export function htmlFromArray(array, targetEl) {
+    var parent;
+    if (typeof targetEl === 'object') {
+        parent = targetEl;
+    } else {
+        parent = document.createElement(targetEl)
+    }
+    array.forEach((el) => {
+        const node = document.createElement(el.tag);
+        if (el.text) { node.textContent = el.text; }
+        if (el.attr) {
+            Object.entries(el.attr).forEach(([key, value]) => {
+                if (key == 'class') {
+                    value = Array.from(value).join(' '); // for some reason arrays in loop aren't returned as arrays so this converts it
+                }
+                node.setAttribute(key, value);
+            });
+        }
+        if (el.html) { node.innerHTML = el.html; }
+        if (el.children) {
+            htmlFromArray(el.children, node);
+        }
+        parent.appendChild(node);
+    });
+    return parent
 }

--- a/assets/js/general.js
+++ b/assets/js/general.js
@@ -1,51 +1,12 @@
 import * as func from './functions.js';
 
-// ---------------------- Toolbar: button functions ---------------------
-const buttonsMenu = body.querySelector('.git-wiki-tools');
-
-// Page width toggle
-const pageWidthToggleButton = buttonsMenu.querySelector('.page-width-toggle');
-
-expandPageWidthTooltip(checkPageWidth('body'));
-
-pageWidthToggleButton.addEventListener('click', (e) => {
-    expandPageWidth(!checkPageWidth('body'));
-    expandPageWidthTooltip(checkPageWidth('body'));
-});
-
-function expandPageWidthTooltip(expand) {
-    const tooltip = pageWidthToggleButton.querySelector('.tooltip');
-    if (expand) {
-        tooltip.textContent = 'Contract Page Width';
-    } else {
-        tooltip.textContent = 'Expand Page Width';
-    }
-}
-
-// Overflow menu
-const moreOptionsMenu = buttonsMenu.querySelector('.more-options');
 body.addEventListener('click', (e) => {
+    const tar = e.target;
+
     // Dismiss mobile menu if clicked outside it
-    if (e.target.closest('.menu-open .git-wiki-page')) {
+    if (tar.closest('.mobile-menu-open .git-wiki-page')) {
         mobileMainMenuToggle();
-    }
-
-    // Detect if clicked within overflow menu
-    if (e.target.closest('.more-options')) {
-        if (e.target.classList.contains('primary-button')) {
-            if (!moreOptionsMenu.classList.contains('menu-open')) {
-                moreOptionsVisible(true);
-            } else {
-                moreOptionsVisible(false);
-            }
-        }
-        return;
-    }
-    moreOptionsVisible(false); // Dismiss if clicked elsewhere
-
-    function moreOptionsVisible(state) {
-        moreOptionsMenu.classList.toggle('menu-open', state);
-        moreOptionsMenu.parentNode.classList.toggle('menu-visible', state);
+        return
     }
 });
 
@@ -58,55 +19,84 @@ function radioButtonActivate(buttonsArray, name) {
 }
 
 
-// --------------------------- Theme switching --------------------------
-const themeButtons = {
-    light: buttonsMenu.querySelector('.theme-light-switcher a'),
-    dark: buttonsMenu.querySelector('.theme-dark-switcher a'),
-}
-const themeRadio = themeButtons.light.closest('.menu-radio');
+// ---------------------- Toolbar: button functions ---------------------
+const buttonsMenu = body.querySelector('.git-wiki-tools'),
+      pageWidthToggleButton = buttonsMenu.querySelector('.page-width-toggle');
 
-radioButtonActivate(themeButtons, checkTheme());
-
-themeRadio.addEventListener('click', (e) => {
-    if (func.matchObjVal(themeButtons, e.target)) {
-        var themeType = func.getKeyByValue(themeButtons, e.target);
-        setClassSetting(body, themeType, themeClassPrefix);
-        radioButtonActivate(themeButtons, themeType);
-    }
+func.waitForElements(body, '.tooltip').then(() => {
+    expandPageWidthTooltip(checkPageWidth('body'));
+    pageWidthToggleButton.addEventListener('click', (e) => {
+        expandPageWidth(!checkPageWidth('body'));
+        expandPageWidthTooltip(checkPageWidth('body'));
+    });
 });
+
+function expandPageWidthTooltip(expand) {
+    let button = pageWidthToggleButton.querySelector('a'),
+        label = body.querySelector('.tooltip .tooltip-label'),
+        text = 'Expand',
+        suffix = ' Page Width';
+    if (expand) {
+        text = 'Contract';
+    }
+    button.setAttribute('data-tooltip-text', text + suffix);
+    label.textContent = text + suffix;
+}
+
+
+// --------------------------- Theme switching --------------------------
+export function themeSwitching(menu) {
+    const themeButtons = {
+        light: menu.querySelector('.theme-light-switcher a'),
+        dark: menu.querySelector('.theme-dark-switcher a'),
+    }
+    const themeRadio = themeButtons.light.closest('.menu-radio');
+
+    radioButtonActivate(themeButtons, checkTheme());
+
+    themeRadio.addEventListener('click', (e) => {
+        if (func.matchObjVal(themeButtons, e.target)) {
+            var themeType = func.getKeyByValue(themeButtons, e.target);
+            setClassSetting(body, themeType, themeClassPrefix);
+            radioButtonActivate(themeButtons, themeType);
+        }
+    });
+}
 
 
 // ---------------------- Header graphic switching ----------------------
-const graphicButtons = {
-    default: buttonsMenu.querySelector('.header-graphic-switcher-default a'),
-    second: buttonsMenu.querySelector('.header-graphic-switcher-second a'),
-}
-const graphicRadio = graphicButtons.default.closest('.menu-radio');
-const headerElements = {
-    desktop: body.querySelector('.header-graphic-desktop-image'),
-    mobile: body.querySelector('#git-wiki-mobile-header a'),
-}
+export function headerGraphicSwitching(menu) {
+    const graphicButtons = {
+        default: menu.querySelector('.header-graphic-switcher-default a'),
+        second: menu.querySelector('.header-graphic-switcher-second a'),
+    }
+    const graphicRadio = graphicButtons.default.closest('.menu-radio');
+    const headerElements = {
+        desktop: body.querySelector('.header-graphic-desktop-image'),
+        mobile: body.querySelector('#git-wiki-mobile-header a'),
+    }
 
-radioButtonActivate(graphicButtons, checkGraphic(Object.keys(graphicButtons)[0])); // return first key name if no match
+    radioButtonActivate(graphicButtons, checkGraphic(Object.keys(graphicButtons)[0])); // return first key name if no match
 
-graphicRadio.addEventListener('click', (e) => {
-    const defaultClass = graphicClassPrefix + '-' + Object.keys(graphicButtons)[0];
-    if (func.matchObjVal(graphicButtons, e.target)) {
-        var graphicType = func.getKeyByValue(graphicButtons, e.target);
-        var currentClass = graphicClassPrefix + '-' + graphicType;
-        var priorClass = checkPriorClass(body, graphicClassPrefix, defaultClass); // store the last used image class for transition purposes
-        var inlineStyle = '--header-graphic-from: var(--' + priorClass + '); --header-graphic-to: var(--' + currentClass + ')';
-        radioButtonActivate(graphicButtons, graphicType);
-        setClassSetting(body, graphicType, graphicClassPrefix);
-        for (let key in headerElements) {
-            headerElements[key].style.cssText = inlineStyle; // define CSS variables via inline style
-            if (priorClass != currentClass) {
-                animReflow(headerElements[key]); // prevent animation retrigger if clicking same button
-                animReflow(headerElements.desktop.parentNode.parentNode); // wrapper element
+    graphicRadio.addEventListener('click', (e) => {
+        const defaultClass = graphicClassPrefix + '-' + Object.keys(graphicButtons)[0];
+        if (func.matchObjVal(graphicButtons, e.target)) {
+            var graphicType = func.getKeyByValue(graphicButtons, e.target);
+            var currentClass = graphicClassPrefix + '-' + graphicType;
+            var priorClass = checkPriorClass(body, graphicClassPrefix, defaultClass); // store the last used image class for transition purposes
+            var inlineStyle = '--header-graphic-from: var(--' + priorClass + '); --header-graphic-to: var(--' + currentClass + ')';
+            radioButtonActivate(graphicButtons, graphicType);
+            setClassSetting(body, graphicType, graphicClassPrefix);
+            for (let key in headerElements) {
+                headerElements[key].style.cssText = inlineStyle; // define CSS variables via inline style
+                if (priorClass != currentClass) {
+                    animReflow(headerElements[key]); // prevent animation retrigger if clicking same button
+                    animReflow(headerElements.desktop.parentNode.parentNode); // wrapper element
+                }
             }
         }
-    }
-});
+    });
+}
 
 function animReflow(el) {
     // Trigger re-flow so CSS animation can play again
@@ -299,23 +289,23 @@ window.onscroll = function() {
 }
 
 // Override default hamburger menu inline onclick behavior
-var pageWrapper = body.querySelector('body > .wrapper'),
-    rootHtml = document.querySelector('html');
-const mobileHamburger = body.querySelector('#git-wiki-mobile-header > button');
+var pageWrapper = body.querySelector('body > .wrapper');
+const rootHtml = document.querySelector('html'),
+      mobileHamburger = body.querySelector('#git-wiki-mobile-header > button');
 mobileHamburger.removeAttribute('onclick'); // disable default theme onclick behavior
 mobileHamburger.addEventListener('click', (e) => {
     mobileMainMenuToggle();
 });
 
 export function mobileMainMenuToggle() {
-    if (pageWrapper.classList.contains('menu-open')) {
+    if (pageWrapper.classList.contains('mobile-menu-open')) {
         rootHtml.removeAttribute('style');
-        pageWrapper.classList.remove('menu-open');
-        pageWrapper.classList.add('menu-closed');
+        pageWrapper.classList.remove('mobile-menu-open');
+        pageWrapper.classList.add('mobile-menu-closed');
     } else {
         // Prevent underlying page from being scrollable so header doesn't get dismissed on scroll
         rootHtml.setAttribute('style','overflow: hidden');
-        pageWrapper.classList.remove('menu-closed');
-        pageWrapper.classList.add('menu-open');
+        pageWrapper.classList.remove('mobile-menu-closed');
+        pageWrapper.classList.add('mobile-menu-open');
     }
 }

--- a/assets/js/sidebar.js
+++ b/assets/js/sidebar.js
@@ -16,8 +16,7 @@ for (let key in counters) {
 
 // -------------------- Page URL hierarchy navigation -------------------
 var {curUrl, curUrlRoot} = func.getPageUrls(checkForVirtualPage()),
-    curPage,
-    hasSection;
+    curPage;
 export const sectionIndexFlat = pathTreeFilterArray(searchIndex, 'url', curUrlRoot); // check search index for shared root pages (assumes each path level has its own page)
 var sectionIndex = JSON.parse(JSON.stringify(sectionIndexFlat)); // creates separate reference for array copy so original array doesn't get retroactively modified by subsequent changes
 
@@ -26,7 +25,7 @@ if (sectionIndex.length > 1 && !document.title.includes('Page Not Found')) {
     const spoilerSiblings = sidebar.querySelectorAll('details');
     var spoilerClosedHeight = 0;
     spoilerSiblings.forEach((el) => {
-        spoilerClosedHeight = el.getBoundingClientRect().height;
+        spoilerClosedHeight = func.getRect(el).height;
         el.removeAttribute('open');
     });
 
@@ -186,27 +185,16 @@ function getNestedObjFromValue(array, nestingKey, itemKey, value) {
 }
 
 export function scrollCurrentItemIntoView(currentItem) {
-    scrollToCenter(currentItem, scrollbarWrapper, false, (findPos(sectionSpoiler).top + spoilerClosedHeight));
+    scrollToCenter(currentItem, scrollbarWrapper, false, (func.getRect(sectionSpoiler).top + spoilerClosedHeight));
 }
 
 function scrollToCenter(target, container, toTargetCenter, yOffset) {
     let targetCenter = 0; // by default use top coord to align
     if (toTargetCenter) { targetCenter = (target.clientHeight / 2); }
-    let top = (findPos(container).top + findPos(target).top - (yOffset || 0)) + targetCenter,
+    let top = (func.getRect(container).top + func.getRect(target).top - (yOffset || 0)) + targetCenter,
         center = top - (container.clientHeight / 2);
     container.scrollTo(0, center);
 }
-
-function findPos(el) {
-    var pos = {top: 0, left: 0};
-    // Recursively travel up parents to output total coords from top-most container
-    do {
-        pos.top += el.offsetTop;
-        pos.left += el.offsetLeft;
-    } while (el = el.offsetParent);
-    return pos
-}
-
 
 function pathTreeFilterArray(array, key, value) {
     var id = 1;

--- a/assets/js/tooltips.js
+++ b/assets/js/tooltips.js
@@ -1,0 +1,252 @@
+import * as func from './functions.js';
+import { themeSwitching, headerGraphicSwitching } from './general.js';
+
+const rootHtml = document.querySelector('html'); // this can't be added to `settings.js` since it slows down immediacy of initial page styling
+var curActive,
+    curActiveMenu,
+    allTriggers,
+    tooltip,
+    tooltipMenu;
+
+func.checkVp(init);
+async function init() {
+    if (tooltip) {
+        // Remove in case on virtual page (to avoid duplication)
+        tooltip.remove();
+        tooltipMenu.remove();
+    }
+    allTriggers = body.querySelectorAll('[data-tooltip-text]');
+    await genPlaceholders();
+
+    allTriggers.forEach((trigger) => {
+        trigger.addEventListener('mouseover', (e) => {
+            let tar = e.target,
+                element = tooltip;
+                if (tar.classList.contains('tooltip-hide')) {
+                    return
+                }
+                if (tar.hasAttribute('data-tooltip-menu')) {
+                    // Prevent other menus from activating on hover if one menu already open
+                    if (!tooltipMenu.classList.contains('tooltip-menu-open')) {
+                        genMenuContent(tar);
+                        element = tooltipMenu;
+                        curActive = tar;
+                        styleContent(tar, true);
+                    }
+                } else {
+                    curActive = tar;
+                    styleContent(tar, true);
+                }
+        });
+
+        trigger.addEventListener('mouseout', (e) => {
+            let tar = e.target;
+            if (tar.hasAttribute('data-tooltip-menu') && tooltipMenu.classList.contains('tooltip-menu-open')) {
+                return
+            } else {
+                styleContent(tar, false);
+            }
+        });
+    });
+}
+
+async function genPlaceholders() {
+    let tooltipArray = [
+        {
+            tag: 'div',
+            attr: {
+                class: ['tooltip']
+            },
+            children: [
+                {
+                    tag: 'div',
+                    attr: {
+                        class: ['tooltip-label']
+                    },
+                    text: ''
+                }
+            ]
+        }
+    ];
+    func.htmlFromArray(tooltipArray, body);
+    tooltip = body.querySelector('.tooltip');
+
+    let menuAdd = {
+        tag: 'div',
+        attr: {
+            class: ['menu-content']
+        }
+    }
+
+    tooltipArray[0].attr.class.push('menu');
+    tooltipArray[0].children.push(menuAdd);
+    func.htmlFromArray(tooltipArray, body);
+    tooltipMenu = body.querySelector('.tooltip.menu');
+}
+
+function genMenuContent(trigger) {
+    let menu = trigger.getAttribute('data-tooltip-menu'),
+        content = tooltipMenu.querySelector('.menu-content'),
+        html;
+    content.innerHTML = '';
+
+    if (menu == 'more-options') {
+        let deleteUrl = trigger.getAttribute('data-delete-page-url');
+        html = `
+            <div class="menu-radio">
+                <div class="menu-button theme-light-switcher"><a class="iconed icon-toolbar icon-themes-light"></a></div>
+                <div class="menu-button theme-dark-switcher"><a class="iconed icon-toolbar icon-themes-dark"></a></div>
+            </div>
+            <div class="menu-radio">
+                <div class="menu-button header-graphic-switcher-default"><a class="graphic-button"></a></div>
+                <div class="menu-button header-graphic-switcher-second"><a class="graphic-button"></a></div>
+            </div>
+            <hr/>
+            <div class="menu-button standalone delete">
+                <a target="_blank" href="` + deleteUrl + `">
+                    <span class="iconed icon-toolbar icon-delete label dim">Delete Page</span>
+                </a>
+            </div>
+        `
+        content.innerHTML = html;
+        themeSwitching(tooltipMenu);
+        headerGraphicSwitching(tooltipMenu);
+    }
+}
+
+function styleContent(trigger, state) {
+    let menu = trigger.hasAttribute('data-tooltip-menu'),
+        element = menu ? tooltipMenu : tooltip,
+        menuOpen = element.classList.contains('tooltip-menu-open');
+    toggleVis(element, state);
+    let triggerRect = func.getRect(trigger),
+        tooltipRect = func.getRect(element),
+
+        // Since `getComputedStyle` outputs the immediate rendered width on click (prior to any transitions/anims ending) the final width can't be obtained ASAP so this checks the max menu width instead
+        maxMenu = menuOpen ? parseInt(getComputedStyle(element).getPropertyValue('--max-width-open')) : 0,
+        spacing = parseInt(getComputedStyle(body).getPropertyValue('--spacing-primary')),
+        min = (element.getAttribute('data-last-width') / 2) - (spacing / 2),
+        max = (window.innerWidth - (element.getAttribute('data-last-width') / 2)) - (spacing / 2),
+        menuWidthDiff = menuOpen ? Math.round((maxMenu - tooltipRect.width) / 2) : 0,
+        menuOpenOffset = ((menuWidthDiff * 2) + triggerRect.left > max) ? menuWidthDiff : 0, // right-most menus
+
+        top = Math.round(triggerRect.top - body.scrollTop),
+        left = Math.round(func.clamp(triggerRect.left + (triggerRect.width / 2), min, max)),
+        label = element.querySelector('.tooltip-label');
+
+    // Left-most menus
+    if (menuOpenOffset == 0 && (triggerRect.left - (menuWidthDiff * 2) < min)) {
+        menuOpenOffset = (-1 * menuWidthDiff);
+    }
+
+    // If function triggered by viewport/scroll update only positions
+    if (state === undefined) {
+        element.style.cssText = element.style.cssText.replace(/(?<=top: )[-0-9]+(?=px)/, top).replace(/(?<=left: )[-0-9]+(?=px)/, left);
+    } else {
+        element.style.cssText = '--top: ' + top + 'px; --left: ' + left + 'px; --menu-open-offset: ' + menuOpenOffset + 'px;';
+    }
+
+    element.classList.toggle('offset-add', trigger.classList.contains('primary-button'));
+    label.textContent = trigger.getAttribute('data-tooltip-text');
+}
+
+function toggleVis(el, state) {
+    if (state) {
+        el.classList.add('visible');
+        el.classList.remove('hidden');
+    } else {
+        if (!el.classList.contains('tooltip-menu-open')) {
+            el.classList.remove('visible');
+            el.classList.add('hidden');
+        }
+    }
+}
+
+function menuOpen(state, el) {
+    var target;
+    if (el) {
+        target = el;
+        toggle(target);
+    } else {
+        if (curActiveMenu) {
+            target = curActiveMenu;
+            if (state) {
+                toggle(target);
+            } else {
+                toggle(target);
+                curActiveMenu = null;
+            }
+        }
+    }
+    function toggle(el) {
+        tooltipMenu.classList.toggle('tooltip-menu-open', state);
+        el.classList.toggle('tooltip-menu-open', state);
+
+        // Add class to hide specific adjacent sibling tooltips that would otherwise overlap while menu open
+        if (el.closest('.git-wiki-tools')) {
+            let wrapper = el.closest('.git-wiki-tools'),
+                buttons = wrapper.querySelectorAll('.primary-button');
+            buttons.forEach((button) => {
+                button.classList.toggle('tooltip-hide', state);
+            });
+        }
+    }
+}
+
+body.addEventListener('click', (e) => {
+    const tar = e.target;
+
+    if (tar.hasAttribute('data-tooltip-menu') || tar.closest('.tooltip.menu')) {
+        if (tar.hasAttribute('data-tooltip-menu')) {
+            e.preventDefault();
+            if (!tooltipMenu.classList.contains('tooltip-menu-open')) {
+                genMenuContent(tar); // always regen content
+                tooltipMenu.setAttribute('data-last-width', func.getRect(tooltipMenu).width); // store width from prior to click, to preserve any future offset
+                menuOpen(true, tar);
+                styleContent(tar, true);
+                curActiveMenu = tar;
+            } else {
+                menuOpen(false, tar);
+            }
+        }
+        return
+    }
+
+    menuOpen(false); // Dismiss if clicked elsewhere
+    toggleVis(tooltipMenu, false);
+    tooltipMenu.setAttribute('data-last-width','');
+});
+
+// Account for new position on scroll and viewport/body resizing
+let scrollPriorPos = 0,
+    ticking = false;
+document.addEventListener("scroll", (event) => {
+  scrollPriorPos = window.scrollY;
+  if (!ticking) {
+    // Throttle scroll event updates
+    window.requestAnimationFrame(() => {
+      updatePos();
+      ticking = false;
+    });
+    ticking = true;
+  }
+});
+
+var resizePriorWidth = 0;
+const resize = new ResizeObserver(entries => {
+  for (const entry of entries) {
+    const width = entry.borderBoxSize?.[0].inlineSize;
+    if (typeof width === 'number' && width !== resizePriorWidth) {
+        resizePriorWidth = width;
+        updatePos();
+    }
+  }
+});
+
+resize.observe(rootHtml, {box: 'border-box'});
+resize.observe(body, {box: 'border-box'}); // necessary since page width toggle can affect body width independently of viewport width
+
+function updatePos() {
+    if (curActive) { styleContent(curActive); }
+    if (curActiveMenu) { styleContent(curActiveMenu); }
+}

--- a/assets/js/virtualpages.js
+++ b/assets/js/virtualpages.js
@@ -218,11 +218,19 @@ async function stylePage(item) {
             edit: toolbar.querySelector('.tools-button.edit:not(.prose) a'),
             history: toolbar.querySelector('.tools-button.history a'),
             source: toolbar.querySelector('.tools-button.source a'),
-            delete: toolbar.querySelector('.tools-button.more-options .delete a'),
+            delete: toolbar.querySelector('.tools-button.more-options a'),
             proseEdit: toolbar.querySelector('.tools-button.prose.edit a')
         }
         for (let key in buttonLinks) {
-            buttonLinks[key].href = buttonLinks[key].href.replace(/\/master\/+wiki\/(.*)/gm, '/master' + item.filePath)
+            if (key == 'delete') {
+                buttonLinks[key].setAttribute('data-delete-page-url', replaceLink(buttonLinks[key].getAttribute('data-delete-page-url')));
+            } else {
+                buttonLinks[key].href = replaceLink(buttonLinks[key].href)
+            }
+        }
+
+        function replaceLink(string) {
+            return string.replace(/\/master\/+wiki\/(.*)/gm, '/master' + item.filePath);
         }
 
         func.checkVp(generateToc);


### PR DESCRIPTION
- Tooltips now applicable to any element by adding an attribute (`data-tooltip-text`).
- Element wrapping is no longer performed so tooltips be applied also to absolutely positioned elements.
- Tooltip menu content now handled centrally via script and the same menu can be applied to multiple elements.
- Tooltip menus triggered from elements near edge of viewport will expand in a way that keeps the menu within the viewport.