### PR TITLE
Updated index build handling

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -53,6 +53,10 @@ jobs:
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}" --config _config.yml,_config-github.yml
         env:
           JEKYLL_ENV: production
+      - name: Run search index build script
+        run: |
+          ./build-search-indexes.ps1
+        shell: pwsh
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3

--- a/build-search-indexes.ps1
+++ b/build-search-indexes.ps1
@@ -220,7 +220,7 @@ $extraFiles = [System.Collections.ArrayList]@(
 
 # Output to final rendered site directory
 # Note: requires full output directory structure exists prior to script running, hence why the Jekyll hook from `run-index-build.rb` plugin, that calls this script, is set to run after the rest of the site has been generated.
-$indexFile = "assets/js/mainindex.js"
+$indexFile = "_site/assets/js/mainindex.js"
 
 $items = Generate-Index -PathDirs $rootDirs -PathExtraFiles $extraFiles
 
@@ -236,7 +236,7 @@ $rootDirs = [System.Collections.ArrayList]@(
     "wiki/Entity_Reference/"
 )
 
-$indexFile = "assets/js/virtualindex.js"
+$indexFile = "_site/assets/js/virtualindex.js"
 
 $items = Generate-Index -PathDirs $rootDirs -IsVirtualPage $true
 


### PR DESCRIPTION
- Testing running Powershell script via workflow instead for live site as it may not be finding Powershell during the live build, which would explain the 404 of the output.