### PR TITLE
add missing exports for search module; without them javascript is

### DIFF
--- a/assets/js/mainindex.js
+++ b/assets/js/mainindex.js
@@ -1,0 +1,1 @@
+export const mainIndex = [];

--- a/assets/js/virtualindex.js
+++ b/assets/js/virtualindex.js
@@ -1,0 +1,1 @@
+export const virtualIndex = [];


### PR DESCRIPTION
partially broken while running locally in docker

Uncaught SyntaxError: The requested module 'http://127.0.0.1:4000/assets/js/virtualindex.js' doesn't provide an export named: 'virtualIndex'