### PR TITLE
Increased fetch depth for checkout

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+            fetch-depth: 0 # for recent changes build script
       - name: Setup Ruby
         # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
         uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4


### PR DESCRIPTION
`0` = full commit history. I'm assuming this will resolve the commit history generation of the recent changes build script.  Will see how it affects deployment time, can always lower to a capped value.