### PR TITLE
Query token styling, results page toggling

### DIFF
--- a/_includes/before_toc.html
+++ b/_includes/before_toc.html
@@ -3,7 +3,7 @@
 <div class="page-heading-wrapper {% if page.featured == true %}is-featured{% endif %}">
     <h1 class="page-heading">{{ page.title }}</h1>
     {% if page.featured == true %}
-    <a class="page-featured-indicator" href="/search?q=wiki-featured:true" data-tooltip-text="Featured page"></a>
+    <a class="page-featured-indicator" href="/search?q=featured:true" data-tooltip-text="Featured page"></a>
     {% endif %}
 </div>
 

--- a/assets/css/overrides.css
+++ b/assets/css/overrides.css
@@ -17,7 +17,9 @@
     --radius-circle: 100%;
     --primary-button-diameter: 38px;
     --secondary-button-diameter: 30px;
+
     --color-link-bg-opacity: 0.12;
+    --color-query-dim: hsl(0,0%,53%);
 
     --font-sans: Kibur, "Segoe UI", sans-serif;
     --font-size-base: 16px;
@@ -798,20 +800,90 @@ body.expanded-width-true .icon-toolbar.icon-expand::before {
     margin-bottom: calc(var(--spacing-primary) - var(--spacing-minor));
 }
 
-#search-input {
+.search-input-mirror-wrapper {
     --extra-padding: 0px;
+    --pad-right: calc(var(--spacing-secondary) + var(--clear-width) + var(--extra-padding));
+    --pad-left: var(--spacing-secondary);
+    width: calc(100% - var(--pad-right) - var(--pad-left));
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr;
+    overflow: hidden;
+    margin: 0 var(--pad-right) 0 var(--pad-left);
+    cursor: text;
+}
+
+/* Is now the search field background fill */
+.search-input-mirror-wrapper::before {
     width: 100%;
-    position: relative;
-    padding-right: calc(var(--spacing-secondary) + var(--clear-width) + var(--extra-padding));
+    height: 100%;
+    background: var(--bg-input);
+    content: '';
+    border-radius: var(--radius-primary);
+    position: absolute; /* aligns to .git-wiki-search so that it's full width */
+    left: 0;
+    top: 0;
     z-index: 3;
+}
+
+.search-input-mirror,
+#search-input {
+    grid-column: 1;
+    grid-row: 1;
+    padding: var(--spacing-minor) 0;
+    position: relative;
+    z-index: 3;
+}
+
+.search-input-mirror {
+    color: var(--color-primary);
+    white-space: pre; /* otherwise multiple spaces will be collapsed */
+    pointer-events: none;
+}
+
+.search-input-mirror-token {
+    position: relative;
+}
+
+.search-input-mirror-token.token-negated {
+    color: var(--color-query-dim);
+}
+
+.search-input-mirror-token.token-value[data-operator]::before,
+.search-input-mirror-token.key-prefix.token-value::before {
+    width: calc(100% + 2px);
+    height: calc(100% + 4px);
+    background: var(--color-secondary);
+    content: '';
+    display: inline-block;
+    opacity: 0.1;
+    border-radius: 3px;
+    position: absolute;
+    top: -2px;
+    left: -1px;
+    z-index: -1;
+}
+
+.search-input-mirror .placeholder {
+    opacity: 0.55; /* matches default input placeholder style */
+}
+
+.search-input-peripheral.filters-active ~ .search-input-mirror-wrapper {
+    --extra-padding: calc(var(--filters-counter-width) + var(--spacing-minor)); /* inline CSS var set via JS */
+}
+
+#search-input {
+    width: 100%;
+    background: transparent;
+    color: transparent;
+    caret-color: var(--color-primary);
+    font: inherit;
+    border: 0;
+    outline: none;
 }
 
 #search-input:focus {
     box-shadow: none;
-}
-
-.search-input-peripheral.filters-active ~ #search-input {
-    --extra-padding: calc(var(--filters-counter-width) + var(--spacing-minor)); /* inline CSS var set via JS */
 }
 
 .search-input-peripheral {
@@ -2815,6 +2887,26 @@ footer {
 .search-results-query-info-query {
     font-weight: var(--font-weight-semibold);
     font-style: italic;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-minor) 0;
+}
+
+.search-results-query-info-token-button {
+    display: inline-flex;
+    padding: 0 calc(var(--spacing-minor) / 1.5);
+    border-radius: var(--radius-secondary);
+    cursor: pointer;
+    position: relative;
+}
+
+
+.search-results-query-info-token-button:hover .search-results-query-info-token {
+    color: var(--color-secondary);
+}
+
+.search-results-query-info-token-button.disabled {
+    text-decoration: line-through;
 }
 
 .search-results-filters-wrapper {

--- a/assets/js/searchdata.js
+++ b/assets/js/searchdata.js
@@ -7,15 +7,19 @@ is_wiki_page: false
 
 import * as func from './functions.js';
 import { searchIndex } from './searchindex.js';
+import { parseQuery } from './searchparsequery.js';
 import { sectionIndexFlat, filterArrayForSection } from './sidebar.js';
 import { getParentPath } from './sidebar.js';
 import { isVirtualPage } from './virtualpages.js';
 
 const searchCont = body.querySelector('.git-wiki-search-js'),
       searchInput = searchCont.querySelector('#search-input');
-let inputPeripheral = {},
+let queryTokens,
+    inputPeripheral = {},
     filterActions = {},
     filtersExpanded = false,
+    searchMirrorCont,
+    searchMirror,
     suggestCont,
     suggestList,
     keyNavCurItem,
@@ -175,7 +179,7 @@ const queryHandlingDebounced = func.debounce((val,keyCode) => {
 // Any search operators of the remaining ('leftover') query fuse will handle, with an additional post-search filter function for enforcing exclusions on those remainders (since fuse doesn't handle them correctly).
 function queryPrefixHandling(val, keyCode) {
     const index = lookupIndex(searchFilterLimitToSectionCheck()),
-          { filtered, queryTokens } = yamlLookupPrefilter(index, val, yamlKeyMap, fuseDefaultOptions);
+          { filtered } = yamlLookupPrefilter(index, queryTokens, yamlKeyMap, fuseDefaultOptions);
     outputSuggestions(queryTokens, filtered, keyCode);
 }
 
@@ -391,6 +395,32 @@ function createLookupIndex(filtersController) {
 }
 
 function setListeners() {
+    // Redirect clicks outside the input area but within the mirror input container to behave like the input was focused (since the input is now a shorter width so string mirroring works)
+    searchMirrorCont.addEventListener('pointerdown', (e) => {
+        if (e.target == searchInput) return // let actual input handle focus directly
+        e.preventDefault();
+
+        const rect = func.getRect(searchInput),
+              x = e.clientX;
+
+        searchInput.focus();
+        searchInput.dispatchEvent(new FocusEvent('focus'));
+
+        // For clicks outside left/right of input set caret to the start/end (like occurs naturally if input were full width with padding)
+        // Caveat: where this currently differs from natural behavior if when the query is longer than the input width (overflows), as clicking outside will jump the caret to the start/end, rather than closest visible character to pointer within string.
+        if (x < rect.left) {
+            searchInput.setSelectionRange(0,0);
+        } else if (x > rect.right) {
+            const l = searchInput.value.length;
+            searchInput.setSelectionRange(l, l);
+        }
+    });
+
+    searchInput.addEventListener('input', (e) => {
+        queryTokens = updateQueryTokens(e.target.value);
+        mirrorText(e.target.value, [...queryTokens.keyPrefixes, ...queryTokens.standalone], searchMirror);
+    });
+
     searchInput.addEventListener('focus', (e) => {
         const val = e.target.value;
         // Trigger output if a value has been pre-filled at page launch
@@ -438,6 +468,7 @@ function setListeners() {
         }
         if (
             e.target == searchInput ||
+            e.target == searchMirrorCont ||
             e.target.closest('.search-filter-actions-wrapper') ||
             e.target.closest('.search-no-results-wrapper') ||
             e.target == suggestCont ||
@@ -479,7 +510,7 @@ function setListeners() {
     });
 
     inputPeripheral.clear.addEventListener('click', (e) => {
-        searchInput.value = null;
+        searchInputChange(null);
         searchClearShow(false);
         searchNoResults(false);
         searchResultsReset();
@@ -487,6 +518,8 @@ function setListeners() {
 }
 
 function initHtmlSearch() {
+    searchMirrorCont = func.createEl('div','search-input-mirror-wrapper');
+    searchMirror = func.createEl('span','search-input-mirror');
     inputPeripheral.cont = func.createEl('div','search-input-peripheral');
     inputPeripheral.clear = func.createEl('button','search-clear-query');
     inputPeripheral.filtersCounter = func.createEl('span','search-filters-counter');
@@ -510,15 +543,14 @@ function initHtmlSearch() {
     for (let [key] of Object.entries(filterActions.buttons)) {
         const l = document.createElement('li');
         filterActions.buttons[key].textContent = suggestionsFilters.getString(key);
-        l.appendChild(filterActions.buttons[key]);
-        filterActions.list.appendChild(l);
+        l.append(filterActions.buttons[key]);
+        filterActions.list.append(l);
     }
 
     inputPeripheral.cont.append(
         inputPeripheral.filtersCounter,
         inputPeripheral.clear
     );
-    searchCont.insertBefore(inputPeripheral.cont, searchInput);
     filterActions.cont.append(
         filterActions.label,
         filterActions.expand,
@@ -528,11 +560,26 @@ function initHtmlSearch() {
         filterActions.cont,
         suggestList
     );
-    searchCont.appendChild(suggestCont);
+    searchCont.append(
+        searchMirrorCont,
+        suggestCont
+    );
+    searchMirrorCont.append(
+        searchMirror,
+        searchInput
+    );
+    searchCont.insertBefore(inputPeripheral.cont, searchMirrorCont);
 
     suggestCont.style.setProperty('--search-input-height',`${searchInput.offsetHeight}px`);
     searchFiltersInitialStates();
     searchClearShow(false);
+    queryTokens = updateQueryTokens(searchInput.value);
+    mirrorText(searchInput.value, [...queryTokens.keyPrefixes, ...queryTokens.standalone], searchMirror);
+}
+
+function updateQueryTokens(val) {
+    const tokens = parseQuery(searchIndex, val, yamlKeyMap);
+    return tokens
 }
 
 // Keyboard navigation
@@ -607,9 +654,14 @@ function resetAll() {
     searchResultsShow(false);
     searchResultsReset();
     searchInput.blur();
-    searchInput.value = null;
+    searchInputChange(null);
     searchClearShow(false);
     searchNoResults(false);
+}
+
+function searchInputChange(val) {
+    searchInput.value = val;
+    searchInput.dispatchEvent(new Event('input', { bubbles: true })); // trigger event firing so mirror text can be updated
 }
 
 function searchResultsReset() {
@@ -731,10 +783,8 @@ function checkOverflow(el) {
 }
 
 function outputSuggestions(queryTokens, input, key) {
-    const query = queryTokens.leftover;
-
     // Only show suggestions if matching a valid YAML prefilter or has non-empty query
-    if (query || queryTokens.includes.length > 0 || queryTokens.excludes.length > 0) {
+    if (queryTokens.leftover || queryTokens.keyPrefixes.length > 0) {
         searchClearShow(true);
     } else {
         searchResultsReset();
@@ -761,7 +811,7 @@ function outputSuggestions(queryTokens, input, key) {
         searchNoResults(false);
 
         const parsedResults = parseResults({
-            query: query,
+            queryTokens: queryTokens,
             input: input,
             range: {
                 max: maxSuggestions
@@ -804,7 +854,7 @@ function presentSuggestions(results, matchWidthBasis) {
 
         function regenHighlights() {
             let els = [];
-            if (result.meta.query) {
+            if (result.meta.queryPositives?.tokens?.length > 0) {
                 els = generateHighlightEls(result, matchWidthBasis, ['search-suggestions-match-string','search-secondary-string']);
             }
             const matchesMore = func.createEl('span','search-suggestions-matches-more'),
@@ -867,7 +917,7 @@ function presentSuggestions(results, matchWidthBasis) {
 // Generate match string elements
 function generateHighlightEls(result, matchWidthBasis, textClasses) {
     const highlightStrings = parseHighlights({
-        query: result.meta.query,
+        queryPositivesSingle: result.meta.queryPositives.single,
         content: result.details.contentCleaned,
         indices: result.matchesCleaned,
         expansionWidth: getExpansionWidth(matchWidthBasis)
@@ -876,7 +926,7 @@ function generateHighlightEls(result, matchWidthBasis, textClasses) {
     const highlightEls = [];
     highlightStrings.forEach((string, i) => {
         const text = func.createEl('span',textClasses);
-        text.appendChild(highlightSubstring(string,result.meta.queryCleaned.replaceAll('"','')));
+        text.appendChild(highlightSubstring(string,result.meta.queryPositives.single));
         highlightEls.push(text);
     });
     return highlightEls
@@ -884,7 +934,7 @@ function generateHighlightEls(result, matchWidthBasis, textClasses) {
 
 function generateMatchLabels(result) {
     const list = [];
-    if (!result.meta.query) {
+    if (!result.meta.queryPositives?.tokens?.length > 0) {
         const label = func.createEl('li','search-more-matches-label');
         label.textContent = `Matched filter`;
         list.push(label);
@@ -900,7 +950,7 @@ function generateMatchLabels(result) {
     }
 
     // Check if string appears in other keys
-    const otherMatches = findKeysWithMatches(result.details, ['title','url','tags'], tokenizeQuery(result.meta.queryCleaned));
+    const otherMatches = findKeysWithMatches(result.details, ['title','url','tags'], result.meta.queryPositives.tokens);
     if (otherMatches) {
         otherMatches.forEach((match) => {
             const label = func.createEl('li','search-more-matches-label');
@@ -920,7 +970,7 @@ function getExpansionWidth(matchWidthBasis) {
 }
 
 function parseResults({
-    query,
+    queryTokens,
     input,
     range = {
         min: 0,
@@ -929,8 +979,12 @@ function parseResults({
 }) {
     let source = JSON.parse(JSON.stringify(input)), /* deep copy */
         totalResults = 0;
-    const queryExclusions = exclusionTokens(query),
-          parsedArray = [];
+    const queryExclusions = queryTokens.standalone.flatMap((q) =>
+        q && q.value && q.negated === true
+            ? [q.value]
+            : []
+    );
+    const parsedArray = [];
 
     // Apply custom filters to results input
     source = filterResultsByExclusionStrings(source,queryExclusions);
@@ -954,14 +1008,13 @@ function parseResults({
             newResult.details.sectionLabel = formatted;
         }
 
-        let queryCleaned,
+        let queryPositives = {},
             contentCleaned,
             matches = [],
             matchesCleaned = [];
-        if (query) {
-            ({ queryCleaned, contentCleaned, matches, matchesCleaned } = parseMatches({
-                query: query,
-                queryExclusions: queryExclusions,
+        if (queryTokens.leftover) {
+            ({ queryPositives, contentCleaned, matches, matchesCleaned } = parseMatches({
+                queryTokens: queryTokens,
                 item: result
             }));
         }
@@ -970,9 +1023,8 @@ function parseResults({
         newResult.details.firstImage = result.image ?? getFirstImageFromText(result.content);
         newResult.matches = matches;
         newResult.matchesCleaned = matchesCleaned;
-        newResult.meta.query = query;
-        newResult.meta.queryCleaned = queryCleaned;
-        newResult.meta.queryExclusions = queryExclusions;
+        newResult.meta.queryTokens = queryTokens;
+        newResult.meta.queryPositives = queryPositives;
         newResult.meta.totalResults = totalResults; // store total results independent of range slice
 
         parsedArray.push(newResult);
@@ -1015,14 +1067,18 @@ function getFirstImageFromText(input) {
 }
 
 function parseMatches({
-    query,
-    queryExclusions = [],
+    queryTokens,
     item
 }) {
-    const queryCleaned = cleanQuery(query,queryExclusions),
-          tokens = tokenizeQuery(queryCleaned);
+    const collapse = s => String(s).replace(/\s+/g, ' ').trim();
+    const tokens = queryTokens.standalone.flatMap((q) =>
+        q && q.value && q.negated !== true
+            ? [collapse(q.value)]
+            : []
+    ); // filter for non-negated values
 
-    const contentCleaned = applyMarkupExclusionsToString(item.content),
+    const tokensSingleString = tokens.map((s) => s.replace(/"/g, '')).join(' '),
+          contentCleaned = applyMarkupExclusionsToString(item.content),
           tokenIndices = getTokenIndices(item.content,tokens),
           tokenIndicesCleaned = getTokenIndices(contentCleaned,tokens),
           flatIndices = Object.values(tokenIndices).flat(), // combine all per-token indices into one array
@@ -1031,18 +1087,26 @@ function parseMatches({
 
     const matches = flatIndices,
           matchesCleaned = filteredIndices;
-    return { queryCleaned, contentCleaned, matches, matchesCleaned }
+    return {
+        queryPositives: {
+            tokens: tokens,
+            single: tokensSingleString
+        },
+        contentCleaned,
+        matches,
+        matchesCleaned
+    }
 }
 
 function parseHighlights({
-    query,
+    queryPositivesSingle,
     content,
     indices,
     totalHighlights = 2,
     expansionWidth
 }) {
     let strings = matchGetHighlights(content, indices, expansionWidth);
-    strings = sortStringsByRelevancy(strings,query.replaceAll('"',''));
+    strings = sortStringsByRelevancy(strings,queryPositivesSingle);
 
     // Check similarity of strings to avoid showing multiple too similar matches
     const similarityThreshold = 0.5,
@@ -1102,17 +1166,6 @@ function findKeysWithMatches(obj, keysToCheck, tokens) {
     return matchingKeys
 }
 
-function tokenizeQuery(query) {
-    const tokenRegex = /"([^"]+)"|\S+/ig;
-    const tokens = [];
-    let match;
-    while ((match = tokenRegex.exec(query)) !== null) {
-        // If token is doublequoted then use the captured group otherwise use whole match
-        tokens.push(match[1] || match[0]);
-    }
-    return tokens
-}
-
 function getTokenIndices(string, tokens) {
     const results = {};
     // Escape tokens for use in regex
@@ -1131,32 +1184,6 @@ function getTokenIndices(string, tokens) {
         }
     }
     return results
-}
-
-function exclusionTokens(query) {
-    const excluded = [];
-
-    // Obtain multi-word exclusion strings (like `!"some term"`)
-    const multiwordRegex = /!"([^"]+?)"/g;
-    let match;
-    while ((match = multiwordRegex.exec(query)) !== null) {
-        excluded.push(match[1]);
-    }
-    const querySansMultiwordExclusions = query.replace(multiwordRegex, '');
-
-    // Strip substrings that are wrapped in double quotes (to avoid parsing any `!` within the remaining query that aren't meant to be exclusion operators)
-    const querySansLiterals = querySansMultiwordExclusions.replace(/"[^"]*"/g, '');
-
-    // Parse remaining query
-    const tokens = querySansLiterals.split(/\s+/); // space delimited
-    tokens.forEach(token => {
-        token = token.trim();
-        if (token.startsWith('!') && token.length > 1) {
-            excluded.push(token.substring(1));
-        }
-    });
-
-    return excluded
 }
 
 // The reason why is used as a post-search filter is for years fuse couldn't handle exclusions across multiple keys (a known issue, they'd get included in results since exclusions weren't treated as global override)
@@ -1561,75 +1588,6 @@ function applyMarkupExclusionsToString(string) {
 }
 
 // Handling for YAML search parameter prefix prefiltering
-
-function extractPrefilterPrefixes(list, query, keyMap = {}) {
-    const prefixPattern = /(?:^|\s)(!?wiki-([a-z0-9_-]+):(?:"([^"]+)"|([^\s"]+)))(?=\s|$)/gi;
-
-    function extractTokens(q) {
-        const includes = [],
-              excludes = [];
-        let m;
-        while ((m = prefixPattern.exec(q)) !== null) {
-            const raw = m[1],
-                  negated = raw.startsWith('!'),
-                  key = m[2],
-                  value = (m[3] ?? m[4]).trim(),
-                  quoted = Boolean(m[3]),
-                  token = { raw, key, value, quoted, negated };
-            if (negated) {
-                excludes.push(token);
-            } else {
-                includes.push(token);
-            }
-        }
-        const leftover = q.replace(prefixPattern, ' ').trim().replace(/\s+/g, ' ');
-        return { includes, excludes, leftover }
-    }
-
-    function getPathValue(obj, path) {
-        return path.split('.').reduce((acc, p) => (acc == null ? undefined : acc[p]), obj)
-    }
-
-    function inputMatches(input, token) {
-        if (input == null) return false
-        const s = String(input).toLowerCase(),
-              v = token.value.toLowerCase();
-        return s.indexOf(v) !== -1 // match token anywhere in key value
-    }
-
-    function tokenMatchesItem(item, token) {
-        const fieldPath = keyMap[token.key];
-        if (!fieldPath) return null // signal unknown prefix instead of false
-        const val = getPathValue(item, fieldPath);
-        if (Array.isArray(val)) return val.some((el) => inputMatches(el, token))
-        return inputMatches(val, token)
-    }
-
-    function applyPreFilters(items, includes, excludes) {
-        let results = items;
-        // Only keep includes that are mapped (ie: ignore unsupported prefixes instead of leaving them in the leftover part of the query)
-        const mappedIncludes = includes.filter((t) => keyMap[t.key]);
-        if (mappedIncludes.length > 0) {
-            results = results.filter((item) =>
-                mappedIncludes.every((token) => tokenMatchesItem(item, token))
-            );
-        }
-        const mappedExcludes = excludes.filter((t) => keyMap[t.key]);
-        if (mappedExcludes.length > 0) {
-            results = results.filter((item) =>
-                !mappedExcludes.some((token) => tokenMatchesItem(item, token))
-            );
-        }
-        return { includes: mappedIncludes, excludes: mappedExcludes, results }
-    }
-
-    const { includes, excludes, leftover } = extractTokens(query),
-          filtered = applyPreFilters(list, includes, excludes);
-
-    return { includes: filtered.includes, excludes: filtered.excludes, leftover, results: filtered.results }
-}
-
-
 function searchPrefilteredResults(results, leftover, fuseOptions = {}) {
     if (!Array.isArray(results) || results.length === 0) return []
 
@@ -1642,29 +1600,162 @@ function searchPrefilteredResults(results, leftover, fuseOptions = {}) {
     if (!leftover) return results // return direct prefiltered array since fuse doesn't rank empty queries
 }
 
-function yamlLookupPrefilter(index, query, keyMap, fuseOptions) {
-    const { includes, excludes, leftover, results } =
-        extractPrefilterPrefixes(index, query, keyMap);
+function applyYamlPrefilters(items, prefixes, keyMap) {
+    function getPathValue(obj, path) {
+        return path.split('.').reduce((acc, p) => (acc == null ? undefined : acc[p]), obj)
+    }
 
-    const queryTokens = { includes: includes, excludes: excludes, leftover: leftover };
+    function inputMatches(input, token) {
+        if (input == null) return false
+        const s = String(input).toLowerCase(),
+              v = (token.value ?? '').toLowerCase();
+        return v.length > 0 && s.indexOf(v) !== -1 // match token anywhere in input
+    }
 
-    // console.log(includes, excludes, leftover, results)
+    function tokenMatchesItem(item, token) {
+        const fieldPath = keyMap[token.key];
+        if (!fieldPath) return null
+        const keyVal = getPathValue(item, fieldPath);
+        if (Array.isArray(keyVal)) return keyVal.some((arrayVal) => inputMatches(arrayVal, token))
+        return inputMatches(keyVal, token)
+    }
 
-    if (!results || results.length === 0) return { filtered: [], queryTokens }
+    const mapped = prefixes.filter((token) => token.key && keyMap[token.key]),
+          includes = mapped.filter((token) => !token.negated),
+          excludes = mapped.filter((token) => token.negated);
+    let results = items;
+    if (includes.length) {
+        results = results.filter((item) => includes.every((token) => tokenMatchesItem(item, token)));
+    }
+    if (excludes.length) {
+        results = results.filter((item) => !excludes.some((token) => tokenMatchesItem(item, token)));
+    }
+    return results
+}
+
+function yamlLookupPrefilter(index, queryTokens, keyMap, fuseOptions) {
+    const filtered = applyYamlPrefilters(index, queryTokens.keyPrefixes, keyMap);
+
+    console.log(queryTokens.keyPrefixes, queryTokens.standalone, queryTokens.leftover);
+
+    if (!filtered || filtered.length === 0) return { filtered: [], queryTokens }
 
     return {
-        filtered: searchPrefilteredResults(results, leftover, fuseOptions),
-        queryTokens
+        filtered: searchPrefilteredResults(filtered, queryTokens.leftover, fuseOptions)
     }
 }
 
+// Search input string mirroring handling for styling query sub-strings
+function mirrorText(text, items, mirrorEl) {
+    styleTokens(text, items, mirrorEl, {
+        mergeNegated: (meta, index) => { return true },
+        spanClassFor: (meta, kind) => {
+            const base = 'search-input-mirror-token',
+                  kindSel = `token-${kind}`;
+            return `${base} ${kindSel}`
+        }
+    })
+}
+
+function styleTokens(text, items, containerEl, callbacks = {}) {
+    containerEl.textContent = '';
+    const frag = document.createDocumentFragment(),
+          segments = [];
+
+    items.forEach((item, i) => {
+        if (!item || !item.indices) return
+
+        const makePair = (pair) => {
+            if (!Array.isArray(pair) || pair.length !== 2) return null
+            const s = Math.max(0, Math.floor(pair[0])),
+                  e = Math.min(text.length, Math.floor(pair[1]));
+            return s < e ? [s, e] : null
+        };
+
+        const opPair = makePair(item.indices.operator),
+              valPair = makePair(item.indices.value);
+
+        if (item.negated && opPair && valPair && callbacks.mergeNegated) {
+            const s = opPair[0], e = Math.max(opPair[1], valPair[1]);
+            segments.push({ start: s, end: e, meta: { operator: item.operator, kind: 'negated', itemIndex: i }});
+        } else {
+            if (opPair) segments.push({ start: opPair[0], end: opPair[1], meta: { operator: item.operator, kind: 'operator', itemIndex: i }});
+            if (valPair) segments.push({ start: valPair[0], end: valPair[1], meta: { operator: item.operator, kind: 'value', itemIndex: i }});
+        }
+    });
+
+    segments.sort((a, b) => a.start - b.start || a.end - b.end); // without sorting here leftover segment operators won't get parsed correctly when intermingled with key prefix operators (at least with how I'm merging the two queryTokens' arrays for the input)
+
+    const groups = new Map();
+    segments.forEach((seg) => {
+        const index = seg.meta.itemIndex;
+        if (!groups.has(index)) groups.set(index, []);
+        groups.get(index).push(seg);
+
+    });
+
+    const mergedMap = new Map();
+    groups.forEach((peers, i) => {
+        const meta = peers[0].meta,
+              item = items[i];
+        if (typeof callbacks.shouldMergeItem === 'function' && callbacks.shouldMergeItem(meta, i)) {
+            const ms = Math.min(...peers.map(p => p.start)),
+                  me = Math.max(...peers.map(p => p.end));
+            mergedMap.set(i, [ms, me]);
+        }
+    });
+
+    let last = 0;
+    segments.forEach((seg) => {
+        const s = seg.start,
+              e = seg.end;
+        if (last < s) frag.appendChild(document.createTextNode(text.slice(last, s)));
+        const sClamped = Math.max(s, last);  // needed so a query like `!example title:fox` doesn't cause the previous negated sub-string to be duplicated after the key prefix sub-string
+
+        if (sClamped < e) {
+            const sel = (callbacks.spanClassFor ? callbacks.spanClassFor(seg.meta, seg.meta.kind) : `token token-${seg.meta.kind}`);
+            const merged = mergedMap.get(seg.meta.itemIndex),
+                  wrapperRange = merged ? merged : null;
+            const wrapper = wrapperRange && typeof callbacks.makeWrapper === 'function'
+                ? callbacks.makeWrapper(seg.meta, wrapperRange[0], wrapperRange[1], segments)
+                : null;
+
+            const span = func.createEl('span');
+            span.className = sel;
+            if (seg.meta.operator) span.setAttribute('data-operator', seg.meta.operator);
+            span.appendChild(document.createTextNode(text.slice(sClamped, e)));
+
+            if (wrapper) {
+                wrapper.appendChild(span);
+                frag.appendChild(wrapper);
+            } else {
+                frag.appendChild(span);
+            }
+
+            last = Math.max(last, e);
+        }
+    });
+    if (last < text.length) frag.appendChild(document.createTextNode(text.slice(last)));
+    if (!frag.childNodes.length) {
+        const span = func.createEl('span','placeholder');
+        span.textContent = searchInput.placeholder;
+        frag.appendChild(span);
+    }
+    containerEl.appendChild(frag);
+}
+
+
+
 export {
     searchInput,
+    searchInputChange,
     pluralResults,
     filterStatesInit,
     fuseDefaultOptions,
     yamlLookupPrefilter,
     yamlKeyMap,
+    styleTokens,
+    updateQueryTokens,
     createResizeObserver,
     createFilterController,
     createLookupIndex,

--- a/assets/js/searchparsequery.js
+++ b/assets/js/searchparsequery.js
@@ -1,0 +1,236 @@
+export function parseQuery(list, query, keyMap = {}) {
+    const prefixPattern = /(?:^|\s)(!?([a-z0-9_-]+):(?:"((?:[^"\\]|\\.)*)"|([^\s"]+)))(?=\s|$)/gi,
+          quotedPattern = /"((?:[^"\\]|\\.)*)"/g;
+
+    function unescapeQuoted(s) {
+        return s.replace(/\\"/g, '"').replace(/\\\\/g, '\\')
+    }
+
+    function getQuotedRanges(q) {
+        return [...q.matchAll(quotedPattern)].map((m) => [m.index, m.index + m[0].length])
+    }
+
+    function checkOverlaps(start, end, ranges) {
+        return ranges.some(([s, e]) => start < e && end > s)
+    }
+
+    // Checks that the range is fully inside wrapped quotes, such as `"title:fox"`, to avoid incorrect parsing with double quoted prefix values like `title:"fox"`
+    function checkFullyInsideQuoted(start, end, ranges) {
+        return ranges.some(([s, e]) => start >= s && (end - 1) < e)
+    }
+
+    function checkInsideRanges(index, ranges) {
+        return ranges.some(([s, e]) => index >= s && index < e)
+    }
+
+    function setOccupiedString(q, occupied) {
+        const chars = Array.from(q);
+        occupied.forEach(([s, e]) => {
+            for (let i = s; i < e && i < chars.length; i++) chars[i] = ' ';
+        });
+        return chars.join('').replace(/\s+/g, ' ').trim()
+    }
+
+    function addOccupied(occupied, start, end) {
+        occupied.push([start, end]);
+    }
+
+    function parsePrefixed(q, occupied, ranges) {
+        const out = [];
+        let m;
+        while ((m = prefixPattern.exec(q)) !== null) {
+            const raw = m[1], key = m[2], quotedVal = m[3], unquotedVal = m[4] || '',
+                  rawStart = m.index + (m[0].length - raw.length),
+                  rawEnd = rawStart + raw.length;
+
+            if (checkFullyInsideQuoted(rawStart, rawEnd, ranges)) continue;
+            if (!keyMap[key]) continue; // leave unmatched prefix for leftover
+
+            const negated = raw.startsWith('!'),
+                  value = quotedVal ? unescapeQuoted(quotedVal) : unquotedVal.trim(),
+                  opMatch = raw.match(/!?(?:[a-z0-9_-]+:)/i),
+                  operator = opMatch ? (negated ? '!' + opMatch[0].replace(/^!/, '') : opMatch[0]) : null,
+                  operatorOffset = operator ? raw.toLowerCase().indexOf(operator.toLowerCase()) : -1,
+                  operatorLength = operator ? operator.length : 0;
+                  // Make sure the value is searched after the operator to avoid unexpected matches with queries like `title:t`
+
+            let valueOffsetInRaw;
+            const indices = {
+                operator: operatorOffset >= 0
+                    ? [rawStart + operatorOffset, rawStart + operatorOffset + operator.length]
+                    : null,
+                value: valueOffsetInRaw >= 0
+                    ? [rawStart + valueOffsetInRaw, rawStart + valueOffsetInRaw + value.length]
+                    : null
+            };
+
+            if (quotedVal) {
+                const quotedFull = `"${m[3]}"`;
+                valueOffsetInRaw = raw.indexOf(quotedFull, operatorLength);
+                // Include quotes in the `value` indices
+                indices.value = valueOffsetInRaw >= 0
+                    ? [rawStart + valueOffsetInRaw, rawStart + valueOffsetInRaw + quotedFull.length]
+                    : null;
+            } else {
+                valueOffsetInRaw = raw.toLowerCase().indexOf(value.toLowerCase(), operatorLength);
+                indices.value = valueOffsetInRaw >= 0
+                    ? [rawStart + valueOffsetInRaw, rawStart + valueOffsetInRaw + value.length]
+                    : null;
+            }
+
+            out.push({ raw, operator, key: key.toLowerCase().trim(), value, quoted: !!quotedVal, negated, indices });
+            addOccupied(occupied, rawStart, rawEnd);
+        }
+        return out
+    }
+
+    function parseLeftoverOperators(q, pattern, occupied, ranges, opExtractor) {
+        const out = [];
+        let m;
+        while ((m = pattern.exec(q)) !== null) {
+            const full = m[0],
+                  rawTrim = full.trimStart ? full.trimStart() : full.trim(),
+                  leadingGap = full.length - rawTrim.length,
+                  rawStart = m.index + leadingGap,
+                  rawEnd = rawStart + rawTrim.length,
+                  raw = q.slice(rawStart, rawEnd),
+                  opInfo = opExtractor(m, rawStart, rawEnd, q);
+
+            if (!opInfo) continue;
+
+            const { operatorIndex, operator, value, quoted, negated } = opInfo;
+
+            if (checkInsideRanges(operatorIndex, ranges)) continue;
+            if (checkOverlaps(rawStart, rawEnd, occupied)) continue;
+
+            let valueStartInRaw = -1;
+            if (quoted) {
+                const quotedText = opInfo.quotedText ?? (`"${m[2] || m[1] || ''}"`), // fallback for double quoted negated leftovers
+                      index = raw.indexOf(quotedText);
+                valueStartInRaw = index >= 0 ? rawStart + index : -1;
+            } else if (value && value.length > 0) {
+                // Find the value nearest the operator. Uses lastIndexOf so trailing operators match the value before the operator (eg: `fox$`)
+                const index = raw.toLowerCase().lastIndexOf(String(value).toLowerCase());
+                valueStartInRaw = index >= 0 ? rawStart + index : -1;
+            }
+
+            const indices = {
+                operator: (typeof operatorIndex === 'number' && operatorIndex >= 0) ? [operatorIndex, operatorIndex + 1] : null,
+                value: valueStartInRaw >= 0
+                    ? [valueStartInRaw, valueStartInRaw + (quoted ? (opInfo.quotedText ? opInfo.quotedText.length : (value.length + 2)) : value.length)]
+                    : null
+            };
+
+            const token = {
+                raw,
+                operator,
+                key: null,
+                value: quoted ? (opInfo.unescapedValue ?? unescapeQuoted(opInfo.quotedRaw ?? (m[2] || m[1] || ''))) : (value || ''),
+                quoted: Boolean(quoted),
+                negated: Boolean(negated),
+                indices
+            };
+
+           out.push(token);
+           addOccupied(occupied, rawStart, rawEnd);
+       }
+       return out
+    }
+
+    function parsePipes(q, occupied, ranges) {
+        const out = [];
+        for (const [i, ch] of Array.from(q).entries()) {
+            if (ch !== '|') continue;
+            if (checkInsideRanges(i, ranges)) continue; // skip if inside double quotes
+            if (checkOverlaps(i, i + 1, occupied)) continue; // check if part of an existing token range
+
+            const token = {
+                raw: '|',
+                operator: '|',
+                key: null,
+                value: undefined,
+                quoted: false,
+                negated: false,
+                indices: { operator: [i, i + 1] }
+            };
+            out.push(token);
+            addOccupied(occupied, i, i + 1);
+        }
+        return out
+    }
+
+    function parseLeftoverTokens(q, occupied) {
+        const out = [],
+              leftoverPattern = /(?:"((?:[^"\\]|\\.)*)"|([^\s"]+))/g;
+        let m;
+
+        while ((m = leftoverPattern.exec(q)) !== null) {
+            const full = m[0],
+                  rawStart = m.index,
+                  rawEnd = rawStart + full.length,
+                  raw = q.slice(rawStart, rawEnd);
+
+            if (checkOverlaps(rawStart, rawEnd, occupied)) continue;
+
+            const quotedText = m[1], unquoted = m[2] || '',
+                  value = quotedText ? unescapeQuoted(quotedText) : unquoted,
+                  quoted = !!quotedText,
+                  valueStartInRaw = rawStart + (quoted ? 1 : 0);
+
+            out.push({
+                raw: raw,
+                operator: undefined,
+                key: null,
+                value,
+                quoted,
+                negated: false,
+                indices: quoted
+                    ? { operator: null, value: [rawStart, rawEnd] }
+                    : (value.length > 0
+                        ? { operator: null, value: [rawStart + raw.indexOf(value), rawStart + raw.indexOf(value) + value.length] }
+                        : { operator: null, value: null })
+            });
+        }
+        return out
+    }
+
+    const quotedRanges = getQuotedRanges(query),
+          occupied = [],
+          keyPrefixes = parsePrefixed(query, occupied, quotedRanges),
+          leftover = setOccupiedString(query, occupied);
+
+    // Leading fuse operators (`!` or `^`)
+    const leadingPattern = /(?:^|\s)([!^])(?:"((?:[^"\\]|\\.)*)"|([^\s"]+))(?=\s|$)/g;
+    const leading = parseLeftoverOperators(query, leadingPattern, occupied, quotedRanges, (m, rawStart) => {
+        const op = m[1],
+              quotedText = m[2],
+              unquoted = m[3],
+              operatorIndex = rawStart + (m[0].trimStart ? m[0].trimStart().indexOf(op) : m[0].trim().indexOf(op));
+        return {
+            operatorIndex,
+            operator: op,
+            value: quotedText ? unescapeQuoted(quotedText) : (unquoted || ''),
+            quoted: !!quotedText,
+            negated: op === '!'
+        }
+    });
+
+    // Trailing fuse operator (`$`)
+    const trailingPattern = /(?:^|\s)(?:"((?:[^"\\]|\\.)*)"|([^\s"]+))(\$)(?=\s|$)/g;
+    const trailing = parseLeftoverOperators(query, trailingPattern, occupied, quotedRanges, (m, rawStart, rawEnd, q) => {
+        const quotedText = m[1], unquoted = m[2], op = m[3],
+              operatorIndex = rawStart + rawEnd - rawStart - 1; // rawEnd - 1
+        return {
+            operatorIndex,
+            operator: op,
+            value: quotedText ? unescapeQuoted(quotedText) : (unquoted || ''),
+            quoted: !!quotedText,
+            negated: false
+        }
+    });
+
+    const pipes = parsePipes(query, occupied, quotedRanges),
+          standalone = [...leading, ...trailing, ...pipes, ...parseLeftoverTokens(query, occupied)];
+
+    return { keyPrefixes, standalone, leftover }
+}

--- a/assets/js/searchresults.js
+++ b/assets/js/searchresults.js
@@ -1,11 +1,14 @@
 import * as func from './functions.js';
 import {
     searchInput,
+    searchInputChange,
     pluralResults,
     filterStatesInit,
     fuseDefaultOptions,
     yamlLookupPrefilter,
     yamlKeyMap,
+    styleTokens,
+    updateQueryTokens,
     createResizeObserver,
     createFilterController,
     createLookupIndex,
@@ -19,8 +22,12 @@ import {
 } from './searchdata.js';
 
 const wikiContentCont = document.getElementById('git-wiki-content'),
-      urlParams = decodeUrl();
-let queryInfoCont,
+      urlParams = decodeUrl(),
+      disabledTokenRanges = new Set();
+let queryCur,
+    queryTokens,
+    queryInfoCont,
+    queryInfoPrefix,
     filtersCont,
     resultsCont,
     resultsContPriorWidth,
@@ -51,8 +58,8 @@ const resultsFilters = createFilterController(filterStatesInit, filterHandlers),
 
 function queryPrefixHandling(val) {
     const index = lookupIndex(resultsFilters.getState('limitToSection'), urlParams.section),
-          { filtered, queryTokens } = yamlLookupPrefilter(index, val, yamlKeyMap, fuseDefaultOptions);
-    return { filtered, queryTokens }
+          { filtered } = yamlLookupPrefilter(index, queryTokens, yamlKeyMap, fuseDefaultOptions);
+    return filtered
 }
 
 initHtmlResults();
@@ -71,10 +78,12 @@ function initSetup() {
     });
 
     // Pre-fill query in search input for easy modification (keep in mind this doesn't adjust of the filters for the suggestions since they're independent)
-    searchInput.value = urlParams.query;
+    searchInputChange(urlParams.query);
 }
 
 function initHtmlResults() {
+    queryCur = urlParams.query;
+    queryTokens = updateQueryTokens(queryCur);
     queryInfoCont = func.createEl('div','search-results-query-info-wrapper');
     resultsCont = func.createEl('ul','search-results-wrapper');
     filtersCont = func.createEl('div','search-results-filters-wrapper');
@@ -111,8 +120,8 @@ function decodeUrl() {
 
 function getResults(range) {
     return parseResults({
-        query: queryPrefixHandling(urlParams.query).queryTokens.leftover,
-        input: queryPrefixHandling(urlParams.query).filtered,
+        queryTokens: queryTokens,
+        input: queryPrefixHandling(queryCur),
         range: range
     });
 }
@@ -124,17 +133,83 @@ function outputResults() {
     presentResults(parsedResults);
 }
 
+function styleQueryResult(text, items, cont) {
+    const queryTokenButtonLookup = new Map(); // for keeping related items in the same button
+    styleTokens(text, items, cont, {
+        mergeNegated: (meta, index) => { return true },
+        shouldMergeItem: (meta, index) => {
+            const item = items[index];
+            if (item) return true // wrap all
+        },
+        spanClassFor: (meta, kind) => {
+            const base = 'search-results-query-info-token',
+                  kindSel = `token-${kind}`;
+            return `${base} ${kindSel}`
+        },
+        makeWrapper: (meta, start, end, segments) => {
+            const key = meta.itemIndex;
+            if (queryTokenButtonLookup.has(key)) return queryTokenButtonLookup.get(key)
+            const button = func.createEl('span','search-results-query-info-token-button');
+            queryTokenButtonLookup.set(key, button);
+            meta.wrapperStart = start;
+            meta.wrapperEnd = end;
+
+            button.addEventListener('click', (e) => {
+                const key = rangeKey(start, end);
+                if (disabledTokenRanges.has(key)) {
+                    disabledTokenRanges.delete(key);
+                    button.classList.remove('disabled');
+                } else {
+                    disabledTokenRanges.add(key);
+                    button.classList.add('disabled');
+                }
+                const newQuery = genNewQuery(segments);
+                queryTokens = updateQueryTokens(newQuery);
+                outputResults();
+            });
+
+            return button
+        }
+    })
+}
+
+function rangeKey(start, end) {
+    return `${start}:${end}`
+}
+
+function genNewQuery(segments) {
+    const chars = Array.from(urlParams.query);
+    segments.forEach((seg) => {
+        const s = seg.meta.wrapperStart,
+              e = seg.meta.wrapperEnd,
+              key = rangeKey(s, e);
+        if (!disabledTokenRanges.has(key)) return
+        // Replace toggled excluded ranges with same length whitespace then later collapse whitespace for new output query
+        for (let i = s; i < e && i < chars.length; i++) {
+            chars[i] = ' ';
+        }
+    });
+    return chars.join('').replace(/\s+/g, ' ').trim();
+}
+
+function updateResultsCounter() {
+    queryInfoPrefix.textContent = `${totalResults} ${func.pluralize(totalResults, pluralResults)} for:`
+}
+
 function presentResults(results) {
     presentResultItems(results);
 
-    // Query info text
-    const queryInfoPrefix = func.createEl('span','search-results-query-info-prefix'),
-          queryInfoQuery = func.createEl('span','search-results-query-info-query');
-    queryInfoPrefix.textContent = `${totalResults} ${func.pluralize(totalResults, pluralResults)} for:`
-    queryInfoQuery.textContent = urlParams.query;
-    queryInfoCont.replaceChildren(queryInfoPrefix, queryInfoQuery);
+    // Query info
+    if (!queryInfoCont.hasChildNodes()) {
+        queryInfoPrefix = func.createEl('span','search-results-query-info-prefix');
+        const queryInfoQuery = func.createEl('div','search-results-query-info-query');
+        styleQueryResult(urlParams.query, [...queryTokens.keyPrefixes, ...queryTokens.standalone], queryInfoQuery);
+        queryInfoCont.replaceChildren(queryInfoPrefix, queryInfoQuery);
+    }
 
-    // Filters list (only generate once)
+    updateResultsCounter();
+
+    // Filters list
     if (!filtersCont.hasChildNodes()) {
         const filtersListCont = func.createEl('ul','search-results-filters-list-wrapper'),
               filtersLabel = func.createEl('span','search-results-filters-label');
@@ -247,7 +322,7 @@ function presentResultItems(results) {
 
             function regenHighlights() {
                 let els = [];
-                if (result.meta.query) {
+                if (result.meta.queryPositives?.tokens?.length > 0) {
                     els = generateHighlightEls(result, matchWidthBasis, 'search-result-match-string');
                 }
                 const moreInfo = moreMatchesCheck(result.matches.length, els.length),

--- a/assets/js/widgets.js
+++ b/assets/js/widgets.js
@@ -270,7 +270,7 @@ function embedShuffled(widget, elms) {
     if (type === 'featured') {
         elms.featuredButton.setAttribute('data-tooltip-text', 'See all featured');
         elms.featuredButton.addEventListener('click', () => {
-            window.location.href = `/search?q=wiki-featured:true`
+            window.location.href = `/search?q=featured:true`
         });
         elms.shuffleButtonSmall.addEventListener('click', () => {
             if (!swapIsAnimating) shuffler.next();

--- a/wiki/Meta/Wiki_Tips/Wiki_Tips.md
+++ b/wiki/Meta/Wiki_Tips/Wiki_Tips.md
@@ -36,17 +36,19 @@ The following operators can be entered in the search box to adjust results.
 
 | Operator | Example | Description |
 |-|-|-|
-| `wiki-title:` | `wiki-title:"infinite heaven"` | Filters results to those containing matches for the given string in any page titles. |
-| `wiki-url:` | `wiki-url:fox` | Filters to matches in any permalinks. |
-| `wiki-tags:` | `wiki-tags:guides` | Filters to matches in page tags. |
-| `wiki-featured:` | `wiki-featured:true` | Filters to matches for featured pages. |
+| `title:` | `title:"infinite heaven"` | Filters results to those containing matches for the given string in any page titles. |
+| `url:` | `url:fox` | Filters to matches in any permalinks. |
+| `tags:` | `tags:guides` | Filters to matches in page tags. |
+| `featured:` | `featured:true` | Filters to matches for featured pages. |
 {:.stretch}
 
-> For any YAML key searches can use either single unquoted string or wrap in double quotes for strings with spaces. They can also be combined with default searches like `wiki-tags:guides fox` to search for all guides containing the string `fox` anywhere.
+> For any YAML key searches can use either single unquoted string or wrap in double quotes for strings with spaces. They can also be combined with default searches like `tags:guides fox` to search for all guides containing the string `fox` anywhere.
 
-> **Tip:** all the YAML key operators support negation, in the form of an exclamation prefix, eg: `!wiki-title:fox` to exclude all pages containing `fox` anywhere in the title.
+> **Tip:** all the YAML key operators support negation, in the form of an exclamation prefix, eg: `!title:fox` to exclude all pages containing `fox` anywhere in the title.
 
-> **Note:** any invalid/mistyped YAML key operators with a value (eg: `wiki-example:something`) will be treated as ignored from the rest of the query.
+> **Tip:** to search literally for an operator + value, such as `title:fox`, wrap them both inside double quotes, like `"title:fox"`.
+
+> **Note:** any invalid/mistyped YAML key operators with a value (eg: `example:something`) will be treated as just a regular string of the query. Like the [default](#default) operators above any leading/trailing operator (beside double quotes, spaces and pipes) will display a subtle background highlight for its associated value (eg. the `fox` part in `title:fox`).
 
 ### Filter toggle buttons
 


### PR DESCRIPTION
- Centralized query token parsing for both YAML prefixes and fuse based leftovers.
- Added query token styling in search field to indicate valid operators.
- Added toggling of query segments in results page by clicking the segment.
- Fixes match counter when fuse-based excluded term is only query.
- Updated YAML prefixes to be just the key, sans the `wiki-` part (instead if wanting to search literally for say `title:fox` can wrap it in double quotes).