### PR TITLE
Search input scroll sync

### DIFF
--- a/assets/css/overrides.css
+++ b/assets/css/overrides.css
@@ -839,6 +839,7 @@ body.expanded-width-true .icon-toolbar.icon-expand::before {
     color: var(--color-primary);
     white-space: pre; /* otherwise multiple spaces will be collapsed */
     pointer-events: none;
+    translate: var(--trans-x, 0px) 0;
 }
 
 .search-input-mirror-token {
@@ -873,13 +874,21 @@ body.expanded-width-true .icon-toolbar.icon-expand::before {
 }
 
 #search-input {
-    width: 100%;
+    width: calc(var(--input-width, 100%) - var(--pad-right) - var(--pad-left)); /* JS sets the absolute width of the full visual input field so drag-selection scrolling can sync between input and mirror */
     background: transparent;
     color: transparent;
     caret-color: var(--color-primary);
     font: inherit;
     border: 0;
     outline: none;
+}
+
+/* Styling when JS disabled/briefly before JS init kicks in (while direct descendant of root container) */
+.git-wiki-search-js > #search-input {
+    width: 100%;
+    background: var(--bg-input);
+    color: inherit;
+    padding: var(--spacing-minor) var(--spacing-secondary);
 }
 
 #search-input:focus {
@@ -923,6 +932,11 @@ body.expanded-width-true .icon-toolbar.icon-expand::before {
     right: 0;
     transition: opacity 150ms, right 150ms;
     pointer-events: none;
+}
+
+/* For search results page where pre-filled input value will appear but no transition needed for counter */
+.search-input-peripheral.clear-instant .search-filters-counter {
+    transition: none;
 }
 
 .search-filters-counter::after {

--- a/assets/js/searchdata.js
+++ b/assets/js/searchdata.js
@@ -416,6 +416,14 @@ function setListeners() {
         }
     });
 
+    // Keep mirror in sync for drag-selection scrolls. Requires the input be same absolute unit width as full visual input field width minus the pseudo padding on the sides (calculated in CSS).
+    searchInput.addEventListener('scroll', (e) => {
+        const width = searchCont.clientWidth,
+              scroll = -searchInput.scrollLeft;
+        searchInput.style.setProperty('--input-width', `${width}px`);
+        searchMirror.style.setProperty('--trans-x', `${scroll}px`);
+    });
+
     searchInput.addEventListener('input', (e) => {
         queryTokens = updateQueryTokens(e.target.value);
         mirrorText(e.target.value, [...queryTokens.keyPrefixes, ...queryTokens.standalone], searchMirror);
@@ -770,7 +778,16 @@ function searchNoResults(state) {
     }
 }
 
-function searchClearShow(state) {
+function searchClearShow(state, instant) {
+    if (instant) {
+        // Use when pre-filling input value and don't want any filter counter transition to occur on init
+        inputPeripheral.cont.classList.add('clear-instant');
+        setTimeout(() => {
+            inputPeripheral.cont.classList.remove('clear-instant');
+        },300);
+    } else {
+            inputPeripheral.cont.classList.remove('clear-instant');
+        }
     inputPeripheral.cont.classList.toggle('clear', state);
     suggestCont.classList.toggle('empty-query', !state);
 }
@@ -1749,6 +1766,7 @@ function styleTokens(text, items, containerEl, callbacks = {}) {
 export {
     searchInput,
     searchInputChange,
+    searchClearShow,
     pluralResults,
     filterStatesInit,
     fuseDefaultOptions,

--- a/assets/js/searchparsequery.js
+++ b/assets/js/searchparsequery.js
@@ -217,9 +217,9 @@ export function parseQuery(list, query, keyMap = {}) {
 
     // Trailing fuse operator (`$`)
     const trailingPattern = /(?:^|\s)(?:"((?:[^"\\]|\\.)*)"|([^\s"]+))(\$)(?=\s|$)/g;
-    const trailing = parseLeftoverOperators(query, trailingPattern, occupied, quotedRanges, (m, rawStart, rawEnd, q) => {
+    const trailing = parseLeftoverOperators(query, trailingPattern, occupied, quotedRanges, (m, rawStart, rawEnd) => {
         const quotedText = m[1], unquoted = m[2], op = m[3],
-              operatorIndex = rawStart + rawEnd - rawStart - 1; // rawEnd - 1
+              operatorIndex = rawEnd - 1;
         return {
             operatorIndex,
             operator: op,

--- a/assets/js/searchresults.js
+++ b/assets/js/searchresults.js
@@ -2,6 +2,7 @@ import * as func from './functions.js';
 import {
     searchInput,
     searchInputChange,
+    searchClearShow,
     pluralResults,
     filterStatesInit,
     fuseDefaultOptions,
@@ -79,6 +80,7 @@ function initSetup() {
 
     // Pre-fill query in search input for easy modification (keep in mind this doesn't adjust of the filters for the suggestions since they're independent)
     searchInputChange(urlParams.query);
+    searchClearShow(true, true);
 }
 
 function initHtmlResults() {


### PR DESCRIPTION
- Added scroll sync for search input mirror so drag-selections and touch scrolls update correctly for overflowed values.
- Added fallback styling for search input when JS disabled/JS init hasn't kicked in yet.
- Show clear query button on results pages by default (mainly so right-side input pseudo padding is always correct on narrower inputs when filter counter visible, prior to focusing the input).