### PR TITLE
Add Kramdown-like attributes support for virtual pages

### DIFF
--- a/assets/js/virtualpages.js
+++ b/assets/js/virtualpages.js
@@ -10,18 +10,20 @@ import { mobileMainMenuToggle } from './general.js';
 import { resetAll as resetSearch } from './searchdata.js';
 
 export const isVirtualPage = checkForVirtualPage();
-var {curUrl, curUrlRoot} = func.getPageUrls(isVirtualPage),
-    pageWrapper = body.querySelector('.git-wiki-page'),
+const pageWrapper = body.querySelector('.git-wiki-page');
+let {curUrl, curUrlRoot} = func.getPageUrls(isVirtualPage),
+    contentWrapper,
+    pageHeading,
     pageObj;
 
 if (isVirtualPage) {
-    var contentWrapper = body.querySelector('#git-wiki-content'),
-        pageHeading = body.querySelector('h1.page-heading');
+    contentWrapper = body.querySelector('#git-wiki-content');
+    pageHeading = body.querySelector('h1.page-heading');
     defaultState();
 
     // Listen for prior history state data on back/forward navigation
     window.addEventListener('popstate', (e) => {
-        var stateObj = e.state;
+        const stateObj = e.state;
         if (stateObj == null) {
             defaultState(true);
         } else {
@@ -34,7 +36,7 @@ if (isVirtualPage) {
 
     body.addEventListener('click', (e) => {
         const tar = e.target;
-        var tarUrl = (tar.tagName == 'A') ? tar.getAttribute('href') : null; // reason for using `getAttribute` vs `.href` is latter resolves to full URL, including domain and protocol
+        let tarUrl = (tar.tagName == 'A') ? tar.getAttribute('href') : null; // reason for using `getAttribute` vs `.href` is latter resolves to full URL, including domain and protocol
         if ((tar.closest('.section-hierarchy-link') && !tar.closest('.root-page')) || (tar.closest('.index.section') && !tarUrl.startsWith('#'))) {
             if (tar.parentElement.classList.contains('section-hierarchy-link')) {
                 tarUrl = tar.parentElement.getAttribute('href');
@@ -65,7 +67,6 @@ if (isVirtualPage) {
             updateFromTarget(e, func.trimTrailFs(tarUrl) + '/');
             return
         }
-        e.stopPropagation();
     }, false);
 
     const searchInput = body.querySelector('#search-input');
@@ -86,7 +87,7 @@ if (isVirtualPage) {
 
     function updateFromTarget(event, targetUrl) {
         event.preventDefault();
-        var tarIndex = func.getIndexByValue(virtualIndex, 'url', targetUrl),
+        const tarIndex = func.getIndexByValue(virtualIndex, 'url', targetUrl),
         tarObj = virtualIndex[tarIndex];
         historyPush(tarObj);
         contentLoaded(false);
@@ -97,7 +98,7 @@ if (isVirtualPage) {
     }
 } else {
     // Tag and all pages auto index handling
-    var autoIndexTags = pageWrapper.querySelectorAll('.index.tags'),
+    const autoIndexTags = pageWrapper.querySelectorAll('.index.tags'),
         autoIndexAllPages = pageWrapper.querySelector('.index.all-pages'),
         autoIndexAllTags = pageWrapper.querySelector('.index.all-tags');
 
@@ -131,9 +132,9 @@ if (isVirtualPage) {
 
     function addItems(parentList, array) {
         parentList.classList.add('full-width');
-        var wrapper = document.createElement('li'),
-            ul = document.createElement('ul'),
-            heading = document.createElement('h2');
+        const wrapper = document.createElement('li'),
+              ul = document.createElement('ul'),
+              heading = document.createElement('h2');
 
         // Note: this heading actually represents all virtual pages but since they're all Entity Reference currently it uses that name (this may change in future if other virtual sections are added)
         heading.id = 'entity-reference';
@@ -143,12 +144,12 @@ if (isVirtualPage) {
         array.sort((a, b) => (a.title > b.title) ? 1: -1); // sort alphabetically by title key
 
         array.forEach((item) => {
-            let wrapper = document.createElement('li'),
-                link = document.createElement('a');
-            link.href = item.url;
-            link.textContent = item.title;
-            wrapper.appendChild(link);
-            ul.appendChild(wrapper);
+            const li = document.createElement('li'),
+                  link = document.createElement('a');
+            link.href = li.url;
+            link.textContent = li.title;
+            li.appendChild(link);
+            ul.appendChild(li);
         });
 
         wrapper.appendChild(ul);
@@ -173,10 +174,16 @@ function filterAllUniqueTags() {
 async function parseMarkdown(item) {
     const liquidMod = await import('https://cdn.jsdelivr.net/npm/liquidjs@10.27.0/+esm'),
           { default: markdownIt } = await import('https://cdn.jsdelivr.net/npm/markdown-it@14.0.0/+esm'),
+          { default: markdownItAttrs } = await import('https://cdn.jsdelivr.net/npm/markdown-it-attrs@5.0.0/+esm'),
           { Liquid, Hash, toPromise } = liquidMod;
 
     const md = markdownIt({
         html: true
+    });
+
+    md.use(markdownItAttrs, {
+        leftDelimiter: '{:', // use Kramdown style opening
+        rightDelimiter: '}'
     });
 
     const ljs = new Liquid({
@@ -205,7 +212,7 @@ async function parseMarkdown(item) {
             });
 
             try {
-                return await this.liquid.renderFile(this.filename, context);
+                return await this.liquid.renderFile(this.filename, context)
             } catch (error) {
                 console.error(error)
             }
@@ -229,8 +236,8 @@ async function parseMarkdown(item) {
 
 async function stylePage(item) {
     if (checkFileExists(item.filePath)) {
-        console.clear(); // remove eg. any 404 link error messages generated on prior page
         await parseMarkdown(item);
+        console.clear(); // remove eg. any 404 link error messages generated on prior page
 
         pageHeading.textContent = item.title;
         document.title = item.title + ' | MGSV Modding Wiki';
@@ -272,7 +279,7 @@ async function stylePage(item) {
         }
 
         function replaceLink(string) {
-            return string.replace(/\/master\/+wiki\/(.*)/gm, '/master' + item.filePath);
+            return string.replace(/\/master\/+wiki\/(.*)/gm, '/master' + item.filePath)
         }
 
         func.checkVp(generateToc);
@@ -286,10 +293,10 @@ function setTagLink(el, string) {
 // https://stackoverflow.com/a/498018
 function generateToc() {
     // Depth of hierarchy will be lowest heading element defined here
-    var headings = pageWrapper.querySelectorAll('h2, h3'),
-        tocWrapper = pageWrapper.querySelector('.toc-toggle'),
+    const tocWrapper = pageWrapper.querySelector('.toc-toggle'),
+          filler = document.createTextNode('.');
+    let headings = pageWrapper.querySelectorAll('h2, h3'),
         toc = tocWrapper.querySelector('#git-wiki-toc'),
-        filler = document.createTextNode('.'),
         result = document.createElement('div'),
         curDepth = 0;
     if (toc) {
@@ -309,28 +316,28 @@ function generateToc() {
         })
         headings = pageWrapper.querySelectorAll('.heading'); // now obtain list in document order
         headings.forEach((heading) => {
-            var li = document.createElement('li'),
-                link = document.createElement('a'),
-                depth = parseInt(heading.tagName.substring(1));
+            const item = document.createElement('li'),
+                  link = document.createElement('a'),
+                  depth = parseInt(heading.tagName.substring(1));
             link.textContent = heading.textContent;
             link.href = '#' + heading.id;
-            li.appendChild(link);
+            item.appendChild(link);
 
             if (depth > curDepth) {
                 // Deeper
-                var ol = document.createElement('ol');
-                ol.appendChild(li);
-                result.appendChild(ol);
-                result = li;
+                const list = document.createElement('ol');
+                list.appendChild(item);
+                result.appendChild(list);
+                result = item;
             } else if (depth < curDepth) {
                 // Shallower
                 let olArr = filterByOl(result);
-                olArr[curDepth - depth].appendChild(li);
-                result = li;
+                olArr[curDepth - depth].appendChild(item);
+                result = item;
             } else {
                 // Same level
-                result.parentNode.appendChild(li);
-                result = li;
+                result.parentNode.appendChild(item);
+                result = item;
             }
             curDepth = depth;
         });
@@ -346,7 +353,7 @@ function generateToc() {
     }
 
     function filterByOl(input) {
-        return filterArrayByObjAttr(parents(input), 'tagName', 'OL');
+        return filterArrayByObjAttr(parents(input), 'tagName', 'OL')
     }
 
     function filterArrayByObjAttr(array, key, attribute) {
@@ -424,7 +431,7 @@ function defaultState(returningFromHistory) {
             contentLoaded(true); // auto reveal root page content
         }
     } else {
-        var pageIndex = func.getIndexByValue(virtualIndex, 'url', curUrl);
+        const pageIndex = func.getIndexByValue(virtualIndex, 'url', curUrl);
         if (pageIndex != -1) {
             pageObj = virtualIndex[pageIndex];
             stylePage(pageObj, true);
@@ -433,7 +440,7 @@ function defaultState(returningFromHistory) {
 }
 
 function fragIdFormat(string) {
-    return string.replace(/[^0-9a-z]/gi,'-').toLowerCase(); // replace all non-alphanumeric characters
+    return string.replace(/[^0-9a-z]/gi,'-').toLowerCase() // replace all non-alphanumeric characters
 }
 
 function breadcrumbs(item) {
@@ -456,12 +463,12 @@ function breadcrumbs(item) {
     pageHeading.parentNode.insertBefore(wrapper, pageHeading);
 
     function splitBreadcrumbs(path) {
-        var paths = removeEmptyArrayItems(path.split('/'));
+        const paths = removeEmptyArrayItems(path.split('/'));
         const segments = paths.map((seg, i) => {
             return {
                 title: seg.replace('_',' ').replace('-',' '),
                 url: '/' + paths.slice(0, i + 1).join('/') + '/'
-            };
+            }
         });
         segments.unshift({
             title: 'Home',
@@ -476,7 +483,7 @@ function breadcrumbs(item) {
 
 function removeEmptyArrayItems(array) {
     let filtered = array.filter(function (item) {
-        return item != '';
+        return item != ''
     });
-    return filtered;
+    return filtered
 }

--- a/wiki/Meta/Virtual_Pages/Formatting_Reference/Formatting_Reference.md
+++ b/wiki/Meta/Virtual_Pages/Formatting_Reference/Formatting_Reference.md
@@ -4,7 +4,7 @@ permalink: /Meta/Virtual_Pages/Formatting_Reference/
 tags: [Meta]
 ---
 
-This page covers formatting for [Virtual Pages](/Meta/Virtual_Pages/) and the differences to the [regular syntax](/Meta/Formatting_Reference/). The differences mostly affect tables syntax and lack of custom classes. Most Markdown formatting is identical though.
+This page covers formatting for [Virtual Pages](/Meta/Virtual_Pages/) and the differences to the [regular syntax](/Meta/Formatting_Reference/).
 
 Click the spoiler labels to show each section.
 
@@ -12,7 +12,7 @@ Click the spoiler labels to show each section.
 
 ## Headings
 
-Headings are identical to the [regular syntax](/Meta/Formatting_Reference/#headings).
+Headings share the [regular syntax](/Meta/Formatting_Reference/#headings).
 
 > Small thing to keep in mind is making sure the first heading on the page is higher hierarchy than any the second heading (if there is one), since the Javascript-based table of contents generation for virtual pages will fail otherwise.\
 \
@@ -23,7 +23,13 @@ Eg: h2 (`##`) followed by a h3 (`###`, or another h2) is fine, just not starting
 
 ## General
 
-General is the same as the [regular syntax](/Meta/Formatting_Reference/#lists), with the exception of lacking support for blockquote classes.
+General styling shares the [regular syntax](/Meta/Formatting_Reference/#lists), with the following differences:
+
+> Blockquote classes don't get applied if the blockquote is within any list item (even if only one level deep).
+{:.important}
+
+> Code syntax highlighting isn't supported in virtual pages currently.
+{:.note}
 
 ---
 
@@ -35,24 +41,35 @@ Footnotes are unsupported in virtual pages.
 
 ## Images
 
-Unlike the [regular syntax](/Meta/Formatting_Reference/#images) there's no support for scaling the images smaller or aligning them to the left/right. So all images will appear their full width and centered.
+Images share the [regular syntax](/Meta/Formatting_Reference/#images), with the following caveat:
 
-{% include spoiler-start %}
-
-![Caption text](/assets/45-0-1448484425.jpg)
-
-    ![Caption text](/assets/45-0-1448484425.jpg)
-
-> As you can see captions are still supported.
-{:.tip}
-
-{% include spoiler-end %}
+> Unlike the Jekyll-based Kramdown parsing of images any filenames containing spaces have to be manually escaped in virtual pages, using `%20` in place of any space character.\
+\
+Eg: `![](/assets/Example%20with%20spaces.jpg)` instead of `![](/assets/Example with spaces.jpg)`.
+{:.important}
 
 ---
 
 ## Lists
 
-Lists share the same syntax as the [regular syntax](/Meta/Formatting_Reference/#lists), with the exception of lacking a `{% raw %}{:.split}{% endraw %}` class feature.
+Lists share the [regular syntax](/Meta/Formatting_Reference/#lists), with the following differences:
+
+> Any nested lists where you want to add a class to the outermost list you need to add a single empty new line between the end of the list and the class, instead of the class being flush beneath the last item. Eg:
+> ```
+> - Parent item
+>    - Child item
+> - Parent item
+>     - Child item
+>
+> {:.split}
+> ```
+{:.note}
+
+> No support for starting an ordered list from a different number (ie: `{:start="<number>"}` is unsupported).
+{:.note}
+
+> Line breaks of list items within spoiler elements **don't** require using `<br/>` (though these are still supported). Instead you can use the typical `\` that would be used outside spoiler elements.
+{:.note}
 
 ---
 
@@ -62,11 +79,14 @@ Lists share the same syntax as the [regular syntax](/Meta/Formatting_Reference/#
 
 **Unique split style with headings using .index class:**
 
-Unsupported in virtual pages.
+Same as [regular syntax](/Meta/Formatting_Reference/#index-lists-incl-auto-generated), with the following caveat:
+
+> As noted in the above [lists](#lists) section caveats you'll need to add the `{:.index}` line with a single empty new line above it, between the end of the last list item and the class line, or else on virtual pages the class won't get applied to the root parent list.
+{:.note}
 
 **Auto-generated index for category pages:**
 
-Same syntax as [regular](/Meta/Formatting_Reference/#index-lists-incl-auto-generated).
+Same as [regular syntax](/Meta/Formatting_Reference/#index-lists-incl-auto-generated).
 
 > **Important:** it's not recommended using this tag-based index include in virtual pages as the LiquidJS parser used for virtual pages struggles with performance of large Liquid loops, causing multi-second page load hitches.<br/>
 <br/>
@@ -92,9 +112,7 @@ This can be used to auto populate a list of direct child pages of a virtual page
 
 ## Tables
 
-Tables differ in their syntax compared to the [regular formatting](/Meta/Formatting_Reference/#tables), in that they *always require* headings (even if they're empty) in order for the entire table to be rendered.
-
-Also the `{% raw %}{:.stretch}{% endraw %}` class feature is unsupported.
+Tables differ in their syntax compared to the [regular formatting](/Meta/Formatting_Reference/#tables), in that they *always require* headings (even if they're empty) in order for the entire table to be rendered. Also a difference in using the `.stretch` class.
 
 {% include spoiler-start %}
 
@@ -124,31 +142,47 @@ So for the **Basic** heading on that linked page instead of being headerless it 
 | Second row text | Second row text | Second row text |
 ```
 
+**Stretched:**
+
+| First row text | First row text | First row text |
+{:.stretch}
+
+```
+| | | |
+|-|-|-|
+| First row text | First row text | First row text |
+
+{:.stretch}
+```
+
+> The stretch class only works if adding an empty new line between the end of the last table cell and the class line, similar to the caveat for adding classes to [lists](#lists) in virtual pages.
+{:.note}
+
 {% include spoiler-end %}
 
 ---
 
 ## Infobox
 
-Infobox shares same syntax as the [regular syntax](/Meta/Formatting_Reference/#infobox).
+Infobox shares the [regular syntax](/Meta/Formatting_Reference/#infobox).
 
 ---
 
 ## Spoiler elements
 
-Spoiler elements share same syntax as the [regular syntax](/Meta/Formatting_Reference/#spoiler-elements).
+Spoiler elements share the [regular syntax](/Meta/Formatting_Reference/#spoiler-elements).
 
 ---
 
 ## Videos
 
-Videos share same syntax as the [regular syntax](/Meta/Formatting_Reference/#videos) with the exeption of lacking classes to change their size/position/caption.
+Videos share the [regular syntax](/Meta/Formatting_Reference/#videos), with the exeption of not supporting adding classes/attributes to change their size/position (so they'll always be full width).
 
 ---
 
 ## Download button
 
-Download button shares same syntax as the [regular syntax](/Meta/Formatting_Reference/#download-button).
+Download buttons share the [regular syntax](/Meta/Formatting_Reference/#download-button).
 
 ---
 

--- a/wiki/Meta/Virtual_Pages/Virtual_Pages.md
+++ b/wiki/Meta/Virtual_Pages/Virtual_Pages.md
@@ -20,8 +20,8 @@ To the reader the pages appear almost identical but under the hood there are som
 
 - Virtual pages require a single 'real', Jekyll-based page to serve as the root basis for all child virtual pages. Eg: the [Entity Reference](/Entity_Reference) page is a real page, while all its child pages are virtual.
 - The URLs have a `/?/` following the real page basis. Such as `/Entity_Reference/?/Fox/`.
-- Virtual pages use a different and more limited kind of Markdown formatting (CommonMark/Github Flavored Markdown) than the version Jekyll uses (Kramdown). This means less options for content styling and some code differences.
-- Page metadata supports fewer values (eg: no redirection support). The metadata block is also formatted differently to avoid Jekyll parsing it.
+- Virtual pages use a different kind of Markdown formatting (CommonMark/Github Flavored Markdown) than the version Jekyll uses (Kramdown). Most styling features remain the same but with some code differences and a few unsupported features.
+- Page metadata doesn't support page redirects. The metadata block is also formatted differently to avoid Jekyll parsing it.
 - Page files use a `.txt` extension rather than `.md` (due to Jekyll seemingly spending time reading `.md` files even if they lack a Jekyll metadata block).
 
 Because virtual pages differ enough from regular pages in these ways this section has its [own Formatting Reference](/Meta/Virtual_Pages/Formatting_Reference) and [Metadata/Organization](/Meta/Virtual_Pages/Metadata_Organization/) pages which list the differences.


### PR DESCRIPTION
Near feature parity with regular pages now. Differences/caveats noted in docs as usual.