### PR TITLE
Add NormalMap AI to FTEX resources

### DIFF
--- a/wiki/FTEXS.md
+++ b/wiki/FTEXS.md
@@ -227,4 +227,5 @@ Gimp is similar.
 
 ## Resources
 
-  -  [Site for making normal maps](https://cpetry.github.io/NormalMap-Online/)
+  - [Site for making normal maps](https://cpetry.github.io/NormalMap-Online/)
+- [NormalMap AI - free normal map and PBR texture generator](https://normalmap.ai/?utm_source=mgsv_wiki&utm_medium=referral&utm_campaign=backlink_2026)


### PR DESCRIPTION
## Summary

Adds NormalMap AI as an additional resource under the FTEX normal-map resources section, while keeping the existing NormalMap Online link.

NormalMap AI is a browser-based normal map and PBR texture generator. It creates normal, roughness, ambient occlusion, metallic, height, and ORM maps from a color/albedo image and includes a real-time 3D preview. The uploaded-image workflow runs locally through WebGL.

- Tool: https://normalmap.ai/
- Demo: https://www.youtube.com/watch?v=H-13KG5UeDY

This is a documentation-only change.